### PR TITLE
Fix serialization of messages when ujson < 1.35 is used

### DIFF
--- a/plenum/common/messages/message_base.py
+++ b/plenum/common/messages/message_base.py
@@ -156,3 +156,6 @@ class MessageBase(Mapping, MessageValidator):
         for index, value in enumerate(list(self.__iter__())):
             h = h * (index + 1) * (hash(value) + 1)
         return h
+
+    def __dir__(self):
+        return self.keys()

--- a/plenum/test/input_validation/test_message_serialization.py
+++ b/plenum/test/input_validation/test_message_serialization.py
@@ -13,3 +13,8 @@ def test_that_service_fields_not_being_serialized():
     deserialized = ZStack.deserializeMsg(serialized)
     service_fields = {'typename', 'schema', 'optional', 'nullable'}
     assert service_fields - set(deserialized) == service_fields
+
+
+def test_that_dir_returns_only_message_keys():
+    message = LedgerStatus(1, 10, None, None, "AwgQhPR9cgRubttBGjRruCRMLhZFBffbejbPipj7WBBm")
+    assert set(dir(message)) == set(message.keys())

--- a/plenum/test/input_validation/test_message_serialization.py
+++ b/plenum/test/input_validation/test_message_serialization.py
@@ -1,0 +1,15 @@
+from plenum.common.messages.node_messages import LedgerStatus
+from stp_zmq.zstack import ZStack
+
+
+def test_that_service_fields_not_being_serialized():
+    """
+    Checks that service fields of validators, like 'typename' and 'schema' ]
+    are excluded from serialized message
+    """
+
+    message = LedgerStatus(1,10,None,None,"AwgQhPR9cgRubttBGjRruCRMLhZFBffbejbPipj7WBBm")
+    serialized = ZStack.serializeMsg(message)
+    deserialized = ZStack.deserializeMsg(serialized)
+    service_fields = {'typename', 'schema', 'optional', 'nullable'}
+    assert service_fields - set(deserialized) == service_fields


### PR DESCRIPTION
Older versions of ujson use dir method of classes for getting fields.
Our message classes contain special service fields like 'typename' and 'schema', which should be excluded from serialized message