### PR TITLE
HashStore is used to recover when the ledger starts, fixed the calcu…

### DIFF
--- a/ledger/compact_merkle_tree.py
+++ b/ledger/compact_merkle_tree.py
@@ -261,10 +261,24 @@ class CompactMerkleTree(merkle_tree.MerkleTree):
     def nodeCount(self) -> int:
         return self.hashStore.nodeCount
 
-    def verifyConsistency(self, expectedLeafCount = -1) -> bool:
-        if expectedLeafCount > 0 and expectedLeafCount != self.leafCount:
+    @staticmethod
+    def get_expected_node_count(leaf_count):
+        """
+        The number of nodes is the number of full subtrees present
+        """
+        count = 0
+        while leaf_count > 1:
+            leaf_count //= 2
+            count += leaf_count
+        return count
+
+    def verify_consistency(self, expected_leaf_count) -> bool:
+        """
+        Check that the tree has same leaf count as expected and the
+        number of nodes are also as expected
+        """
+        if expected_leaf_count != self.leafCount:
             raise ConsistencyVerificationFailed()
-        expectedNodeCount = count_bits_set(self.leafCount)
-        if not expectedNodeCount == self.nodeCount:
+        if self.get_expected_node_count(self.leafCount) != self.nodeCount:
             raise ConsistencyVerificationFailed()
         return True

--- a/ledger/ledger.py
+++ b/ledger/ledger.py
@@ -1,10 +1,8 @@
 import base64
 import logging
 import time
-from collections import OrderedDict
 
 from ledger.compact_merkle_tree import CompactMerkleTree
-from ledger.stores.chunked_file_store import ChunkedFileStore
 from ledger.tree_hasher import TreeHasher
 from ledger.merkle_tree import MerkleTree
 from ledger.serializers.mapping_serializer import MappingSerializer
@@ -12,7 +10,7 @@ from ledger.serializers.json_serializer import JsonSerializer
 from ledger.stores.file_store import FileStore
 from ledger.stores.text_file_store import TextFileStore
 from ledger.immutable_store import ImmutableStore
-from ledger.util import F
+from ledger.util import F, ConsistencyVerificationFailed
 
 
 class Ledger(ImmutableStore):
@@ -71,13 +69,9 @@ class Ledger(ImmutableStore):
             logging.error("Do not know how to recover {}".format(self.tree))
             raise TypeError("Merkle tree type {} is not supported"
                             .format(type(self.tree)))
-
-
-        from ledger.stores.memory_hash_store import MemoryHashStore
-        from ledger.util import ConsistencyVerificationFailed
         start = time.perf_counter()
         if not self.tree.hashStore \
-                or isinstance(self.tree.hashStore, MemoryHashStore) \
+                or not self.tree.hashStore.is_persistent \
                 or self.tree.leafCount == 0:
             logging.debug("Recovering tree from transaction log")
             self.recoverTreeFromTxnLog()

--- a/ledger/ledger.py
+++ b/ledger/ledger.py
@@ -79,11 +79,11 @@ class Ledger(ImmutableStore):
         if not self.tree.hashStore \
                 or isinstance(self.tree.hashStore, MemoryHashStore) \
                 or self.tree.leafCount == 0:
-            logging.info("Recovering tree from transaction log")
+            logging.debug("Recovering tree from transaction log")
             self.recoverTreeFromTxnLog()
         else:
             try:
-                logging.info("Recovering tree from hash store of size {}".
+                logging.debug("Recovering tree from hash store of size {}".
                               format(self.tree.leafCount))
                 self.recoverTreeFromHashStore()
             except ConsistencyVerificationFailed:

--- a/ledger/merkle_tree.py
+++ b/ledger/merkle_tree.py
@@ -69,6 +69,6 @@ class MerkleTree:
         """
 
     @abstractmethod
-    def verifyConsistency(self, expectedLeafCount) -> bool:
+    def verify_consistency(self, expectedLeafCount) -> bool:
         """
         """

--- a/ledger/stores/file_hash_store.py
+++ b/ledger/stores/file_hash_store.py
@@ -27,6 +27,10 @@ class FileHashStore(HashStore):
         self.nodeSize = nodeSize
         self.leafSize = leafSize
 
+    @property
+    def is_persistent(self) -> bool:
+        return True
+
     @staticmethod
     def write(data, store, size):
         if not isinstance(data, bytes):

--- a/ledger/stores/hash_store.py
+++ b/ledger/stores/hash_store.py
@@ -137,6 +137,14 @@ class HashStore:
         pos = self.getNodePosition(start, height)
         return self.readNode(pos)
 
+    @property
+    def is_consistent(self) -> bool:
+        """
+        Returns True if number of nodes are consistent with number of leaves
+        """
+        from ledger.compact_merkle_tree import CompactMerkleTree
+        return self.nodeCount == CompactMerkleTree.get_expected_node_count(self.leafCount)
+
     @staticmethod
     def _validatePos(start, end=None):
         if end:

--- a/ledger/stores/hash_store.py
+++ b/ledger/stores/hash_store.py
@@ -8,6 +8,10 @@ class HashStore:
     """
     Store of nodeHashes and leafHashes mapped against their sequence numbers.
     """
+    @property
+    @abstractmethod
+    def is_persistent(self) -> bool:
+        pass
 
     @abstractmethod
     def writeLeaf(self, leafHash):

--- a/ledger/stores/memory_hash_store.py
+++ b/ledger/stores/memory_hash_store.py
@@ -6,6 +6,10 @@ class MemoryHashStore(HashStore):
         self.reset()
         self._closed = False
 
+    @property
+    def is_persistent(self) -> bool:
+        return False
+
     def writeLeaf(self, leafHash):
         self._leafs.append(leafHash)
 

--- a/ledger/test/test_file_hash_store.py
+++ b/ledger/test/test_file_hash_store.py
@@ -15,6 +15,7 @@ def nodesLeaves():
 
 def writtenFhs(tempdir, nodes, leaves):
     fhs = FileHashStore(tempdir)
+    assert fhs.is_persistent
     for leaf in leaves:
         fhs.writeLeaf(leaf)
     for node in nodes:

--- a/ledger/test/test_file_hash_store.py
+++ b/ledger/test/test_file_hash_store.py
@@ -51,6 +51,14 @@ def testSimpleReadWrite(nodesLeaves, tempdir):
     for i, n in enumerate(nds):
         assert nodes[i][2] == n
 
+    # Check that hash store can be closed and re-opened and the contents remain same
+    leaf_count = fhs.leafCount
+    node_count = fhs.nodeCount
+    fhs.close()
+    reopened_hash_store = FileHashStore(tempdir)
+    assert reopened_hash_store.leafCount == leaf_count
+    assert reopened_hash_store.nodeCount == node_count
+
 
 def testIncorrectWrites(tempdir):
     fhs = FileHashStore(tempdir, leafSize=50, nodeSize=50)

--- a/ledger/test/test_ledger.py
+++ b/ledger/test/test_ledger.py
@@ -107,7 +107,7 @@ def testRecoverLedgerFromHashStore(tempdir):
     fhs = FileHashStore(tempdir)
     tree = CompactMerkleTree(hashStore=fhs)
     ledger = Ledger(tree=tree, dataDir=tempdir)
-    for d in range(10):
+    for d in range(100):
         ledger.add(str(d).encode())
     updatedTree = ledger.tree
     ledger.stop()

--- a/ledger/test/test_merkle_proof.py
+++ b/ledger/test/test_merkle_proof.py
@@ -117,9 +117,12 @@ TXN_COUNT = 1000
 def hashStore(request, tdir):
     if request.param == 'File':
         fhs = FileHashStore(tdir)
+        assert fhs.is_persistent
         yield fhs
     elif request.param == 'Memory':
-        yield MemoryHashStore()
+        mhs = MemoryHashStore()
+        assert not mhs.is_persistent
+        yield mhs
 
 
 @pytest.fixture()
@@ -149,7 +152,6 @@ def addTxns(hasherAndTree):
         serNo = d+1
         data = str(serNo).encode()
         auditPaths.append([hexlify(h) for h in m.append(data)])
-        print(m.hashStore.leafCount, m.hashStore.nodeCount)
     return TXN_COUNT, auditPaths
 
 

--- a/ledger/test/test_merkle_proof.py
+++ b/ledger/test/test_merkle_proof.py
@@ -110,6 +110,9 @@ hexlify(c(
 """
 
 
+TXN_COUNT = 1000
+
+
 @pytest.yield_fixture(scope="module", params=['File', 'Memory'])
 def hashStore(request, tdir):
     if request.param == 'File':
@@ -141,15 +144,13 @@ def hasherAndTree(hasher):
 def addTxns(hasherAndTree):
     h, m = hasherAndTree
 
-    txn_count = 1000
-
     auditPaths = []
-    for d in range(txn_count):
+    for d in range(TXN_COUNT):
         serNo = d+1
         data = str(serNo).encode()
         auditPaths.append([hexlify(h) for h in m.append(data)])
-
-    return txn_count, auditPaths
+        print(m.hashStore.leafCount, m.hashStore.nodeCount)
+    return TXN_COUNT, auditPaths
 
 
 @pytest.fixture()
@@ -200,7 +201,7 @@ def testCompactMerkleTree2(hasherAndTree, verifier):
 def testCompactMerkleTree(hasherAndTree, verifier):
     h, m = hasherAndTree
     printEvery = 1000
-    count = 1000
+    count = TXN_COUNT
     for d in range(count):
         data = str(d + 1).encode()
         data_hex = hexlify(data)
@@ -208,6 +209,8 @@ def testCompactMerkleTree(hasherAndTree, verifier):
         audit_path_hex = [hexlify(h) for h in audit_path]
         incl_proof = m.inclusion_proof(d, d+1)
         assert audit_path == incl_proof
+        assert m.nodeCount == m.get_expected_node_count(m.leafCount)
+        assert m.hashStore.is_consistent
         if d % printEvery == 0:
             show(h, m, data_hex)
             print("audit path is {}".format(audit_path_hex))

--- a/plenum/cli/cli.py
+++ b/plenum/cli/cli.py
@@ -252,10 +252,10 @@ class Cli:
             eventloop=eventloop,
             output=out)
 
-        RAETVerbosity = getRAETLogLevelFromConfig("RAETLogLevelCli",
-                                                  Console.Wordage.mute,
-                                                  self.config)
-        RAETLogFile = getRAETLogFilePath("RAETLogFilePathCli", self.config)
+        # RAETVerbosity = getRAETLogLevelFromConfig("RAETLogLevelCli",
+        #                                           Console.Wordage.mute,
+        #                                           self.config)
+        # RAETLogFile = getRAETLogFilePath("RAETLogFilePathCli", self.config)
         # Patch stdout in something that will always print *above* the prompt
         # when something is written to stdout.
         sys.stdout = self.cli.stdout_proxy()

--- a/plenum/persistence/leveldb_hash_store.py
+++ b/plenum/persistence/leveldb_hash_store.py
@@ -17,6 +17,10 @@ class LevelDbHashStore(HashStore):
         self.leavesDb = None
         self.open()
 
+    @property
+    def is_persistent(self) -> bool:
+        return True
+
     def writeLeaf(self, leafHash):
         self.leavesDb.put(str(self.leafCount + 1), leafHash)
         self.leafCount += 1

--- a/plenum/test/input_validation/message_validation/test_prepare_message.py
+++ b/plenum/test/input_validation/message_validation/test_prepare_message.py
@@ -1,9 +1,6 @@
-import pytest
-
 from collections import OrderedDict
 from plenum.common.messages.fields import NonNegativeNumberField, \
-    NonEmptyStringField, \
-    HexField, MerkleRootField, AnyValueField
+    NonEmptyStringField, MerkleRootField
 from plenum.common.messages.node_messages import Prepare
 
 EXPECTED_ORDERED_FIELDS = OrderedDict([

--- a/plenum/test/node_catchup/test_node_request_consistency_proof.py
+++ b/plenum/test/node_catchup/test_node_request_consistency_proof.py
@@ -1,7 +1,4 @@
 import types
-from random import randint
-
-import pytest
 
 from plenum.common.constants import DOMAIN_LEDGER_ID, CONSISTENCY_PROOF
 from plenum.common.ledger import Ledger


### PR DESCRIPTION
…lation for consistency

Recovering from transaction log is slow as each transaction is applied again to the tree.