### PR TITLE
fix ujson version to have the same serialization of composite messages

### DIFF
--- a/plenum/common/messages/node_messages.py
+++ b/plenum/common/messages/node_messages.py
@@ -294,6 +294,7 @@ class MessageRep(MessageBase):
     """
     Purpose: respond to a node for any requested message
     """
+    # TODO: support a setter for `msg` to create an instance of a type according to `msg_type`
     typename = MESSAGE_RESPONSE
     schema = (
         (f.MSG_TYPE.nm, ChooseField(values=MessageReq.allowed_types)),

--- a/plenum/server/message_req_processor.py
+++ b/plenum/server/message_req_processor.py
@@ -76,11 +76,16 @@ class MessageReqProcessor:
         if kwargs['ledger_id'] in self.ledger_ids:
             if 'ledger_status' in kwargs:
                 try:
-                    return LedgerStatus(*kwargs['ledger_status'])
+                    # TODO: move this validation into MessageBase validation.
+                    # TODO: avoid duplication of code here: create an instance of requested class in a one place (a factory?)
+                    # depending on the msg_type
+
+                    # the input is expected as a dict (serialization with ujson==1.33)
+                    return LedgerStatus(**kwargs['ledger_status'])
                 except TypeError as ex:
                     logger.warning(
                         '{} could not create LEDGER_STATUS out of {}'.
-                            format(self, *kwargs['ledger_status']))
+                            format(self, **kwargs['ledger_status']))
             else:
                 return True
 
@@ -116,11 +121,12 @@ class MessageReqProcessor:
                     'seq_no_end'] > 0):
             if 'cons_proof' in kwargs:
                 try:
-                    return ConsistencyProof(*kwargs['cons_proof'])
+                    # the input is expected as a dict (serialization with ujson==1.33)
+                    return ConsistencyProof(**kwargs['cons_proof'])
                 except TypeError as ex:
                     logger.warning(
                         '{} could not create CONSISTENCY_PROOF out of {}'.
-                            format(self, *kwargs['cons_proof']))
+                            format(self, **kwargs['cons_proof']))
             else:
                 return True
 
@@ -165,7 +171,8 @@ class MessageReqProcessor:
                         kwargs['pp_seq_no'] > 0:
             if 'pp' in kwargs:
                 try:
-                    pp = PrePrepare(*kwargs['pp'])
+                    # the input is expected as a dict (serialization with ujson==1.33)
+                    pp = PrePrepare(**kwargs['pp'])
                     if pp.instId != kwargs['inst_id'] or pp.viewNo != kwargs['view_no']:
                         logger.warning('{} found PREPREPARE {} not satisfying '
                                        'query criteria'.format(self, *kwargs['pp']))
@@ -174,7 +181,7 @@ class MessageReqProcessor:
                 except TypeError as ex:
                     logger.warning(
                         '{} could not create PREPREPARE out of {}'.
-                        format(self, *kwargs['pp']))
+                        format(self, **kwargs['pp']))
             else:
                 return True
 
@@ -214,7 +221,8 @@ class MessageReqProcessor:
                                                    kwargs['req_id']))):
             if 'propagate' in kwargs:
                 try:
-                    ppg = Propagate(*kwargs['propagate'])
+                    # the input is expected as a dict (serialization with ujson==1.33)
+                    ppg = Propagate(**kwargs['propagate'])
                     if ppg.request[f.IDENTIFIER.nm] != kwargs['identifier'] or \
                                     ppg.request[f.REQ_ID.nm] != kwargs['req_id']:
                             logger.warning('{} found PROPAGATE {} not '
@@ -224,7 +232,7 @@ class MessageReqProcessor:
                 except TypeError as ex:
                     logger.warning(
                         '{} could not create PROPAGATE out of {}'.
-                            format(self, *kwargs['propagate']))
+                            format(self, **kwargs['propagate']))
             else:
                 return True
 

--- a/plenum/test/common/test_parse_ledger.py
+++ b/plenum/test/common/test_parse_ledger.py
@@ -18,7 +18,7 @@ def tdirWithLedger(tdir):
                 DATA: {
                 NAME: str(d),
                 ALIAS: 'test' + str(d),
-                SERVICES: {VALIDATOR},
+                SERVICES: [VALIDATOR],
                 }
               }
         if d == 1:

--- a/plenum/test/input_validation/test_message_serialization.py
+++ b/plenum/test/input_validation/test_message_serialization.py
@@ -1,4 +1,5 @@
-from plenum.common.messages.node_messages import LedgerStatus
+from plenum.common.messages.node_messages import LedgerStatus, MessageRep
+from plenum.common.types import f
 from stp_zmq.zstack import ZStack
 
 
@@ -18,3 +19,24 @@ def test_that_service_fields_not_being_serialized():
 def test_that_dir_returns_only_message_keys():
     message = LedgerStatus(1, 10, None, None, "AwgQhPR9cgRubttBGjRruCRMLhZFBffbejbPipj7WBBm")
     assert set(dir(message)) == set(message.keys())
+
+def test_serialization_of_submessages_to_dict():
+    message = LedgerStatus(1, 10, None, None, "AwgQhPR9cgRubttBGjRruCRMLhZFBffbejbPipj7WBBm")
+    message_rep = MessageRep(**{
+        f.MSG_TYPE.nm: "LEDGER_STATUS",
+        f.PARAMS.nm: {"ledger_id": 1},
+        f.MSG.nm: message
+    })
+    serialized_message = ZStack.serializeMsg(message).decode()
+    serialized_message_reply = ZStack.serializeMsg(message_rep).decode()
+
+    # check that submessage (LedgerStatus) is serialized to the same dict as it were a common message
+    assert serialized_message in serialized_message_reply
+
+    # check that de-serialized into the same message
+    deserialized_message = LedgerStatus(**ZStack.deserializeMsg(serialized_message))
+    deserialized_submessage = LedgerStatus(**ZStack.deserializeMsg(serialized_message_reply)[f.MSG.nm])
+    assert message == deserialized_message
+    assert message_rep.msg == deserialized_submessage
+    assert message == deserialized_submessage
+

--- a/setup.py
+++ b/setup.py
@@ -58,12 +58,12 @@ setup(
     data_files=[(
         (BASE_DIR, ['data/pool_transactions_sandbox', ])
     )],
-    install_requires=['jsonpickle', 'ujson',
+    install_requires=['jsonpickle', 'ujson==1.33',
                       'prompt_toolkit==0.57', 'pygments',
                       'crypto==1.4.1', 'rlp', 'sha3', 'leveldb',
                       'ioflo==1.5.4', 'semver', 'base58', 'orderedset',
                       'sortedcontainers==1.5.7', 'psutil', 'pip',
-                      'portalocker==0.5.7', 'pyzmq', 'raet', 'ioflo==1.5.4',
+                      'portalocker==0.5.7', 'pyzmq', 'raet',
                       'psutil', 'intervaltree'],
     extras_require={
         'stats': ['python-firebase'],


### PR DESCRIPTION
Fixing blocking issue INDY-406:
ujson serializes composite messages (introduced with MsgReq/Rep feature) differently depending on the version. 
- fixed version of ujson to 1.33 (the same as canonical deb in Ubuntu 16)
- expect submessages to be serialized as a dict.