### PR TITLE
Modify CLI Commands to Reflect New Terminology

### DIFF
--- a/plenum/cli/cli.py
+++ b/plenum/cli/cli.py
@@ -471,7 +471,7 @@ class Cli:
             return True
 
     def _newKeyring(self, matchedVars):
-        if matchedVars.get('new_keyring'):
+        if matchedVars.get('new_wallet'):
             name = matchedVars.get('name')
             conflictFound = self._checkIfIdentifierConflicts(
                 name, checkInAliases=False, checkInSigners=False)

--- a/plenum/cli/cli.py
+++ b/plenum/cli/cli.py
@@ -384,12 +384,12 @@ class Cli:
                 'add_key': PhraseWordCompleter('add key'),
                 'for_client': PhraseWordCompleter('for client'),
                 'new_key': PhraseWordCompleter('new key'),
-                'new_wallet': PhraseWordCompleter('new keyring'),
+                'new_wallet': PhraseWordCompleter('new wallet'),
                 'rename_wallet': PhraseWordCompleter('rename wallet'),
                 'list_ids': PhraseWordCompleter('list ids'),
                 'list_wallet': PhraseWordCompleter('list wallets'),
                 'become': WordCompleter(['become']),
-                'use_id': PhraseWordCompleter('use identifier'),
+                'use_id': PhraseWordCompleter('use DID'),
                 'use_wallet': PhraseWordCompleter('use wallet'),
                 'save_wallet': PhraseWordCompleter('save wallet'),
                 'add_gen_txn': PhraseWordCompleter('add genesis transaction'),
@@ -416,7 +416,7 @@ class Cli:
                 'add_key',
                 'verkey',
                 'for_client',
-                'identifier',
+                'DID',
                 'new_key',
                 'list_ids',
                 'list_wallets',
@@ -988,7 +988,7 @@ class Cli:
             if self.activeWallet and self.activeWallet.defaultId:
                 wallet = self.activeWallet
                 idr = wallet.defaultId
-                self.print("    Identifier: {}".format(idr))
+                self.print("    DID: {}".format(idr))
                 self.print(
                     "    Verification key: {}".format(wallet.getVerkey(idr)))
 
@@ -1065,7 +1065,7 @@ class Cli:
     @staticmethod
     def bootstrapKey(wallet, node, identifier=None):
         identifier = identifier or wallet.defaultId
-        assert identifier, "Client has no identifier"
+        assert identifier, "Client has no DID"
         node.clientAuthNr.addIdr(identifier, wallet.getVerkey(identifier))
 
     def clientExists(self, clientName):
@@ -1291,7 +1291,7 @@ class Cli:
             # TODO make verkey case insensitive
             identifier = matchedVars.get('identifier')
             if identifier in self.externalClientKeys:
-                self.print("identifier already added", Token.Error)
+                self.print("DID already added", Token.Error)
                 return
             self.externalClientKeys[identifier] = verkey
             for n in self.nodes.values():
@@ -1316,10 +1316,10 @@ class Cli:
 
         signer = DidSigner(identifier=identifier, seed=cseed, alias=alias)
         self._addSignerToGivenWallet(signer, wallet, showMsg=True)
-        self.print("Identifier for key is {}".format(signer.identifier))
+        self.print("DID for key is {}".format(signer.identifier))
         self.print("Verification key is {}".format(signer.verkey))
         if alias:
-            self.print("Alias for identifier is {}".format(signer.alias))
+            self.print("Alias for DID is {}".format(signer.alias))
         self._setActiveIdentifier(signer.identifier)
         self.bootstrapClientKeys(signer.identifier, signer.verkey,
                                  self.nodes.values())
@@ -1455,10 +1455,10 @@ class Cli:
                 self.print("Active wallet: {}".
                            format(self._activeWallet.name), newline=False)
                 if self._activeWallet.defaultId:
-                    self.print(" (active identifier: {})\n".
+                    self.print(" (active DID: {})\n".
                            format(self._activeWallet.defaultId), Token.Gray)
                 if len(self._activeWallet.listIds()) > 0:
-                    self.print("Identifiers:")
+                    self.print("DIDs:")
                     withVerkeys = matchedVars.get('with_verkeys') == 'with verkeys'
                     for id in self._activeWallet.listIds():
                         verKey = ""
@@ -1470,7 +1470,7 @@ class Cli:
 
                         self.print("  {}{}".format(id, verKey))
                 else:
-                    self.print("\nNo identifiers")
+                    self.print("\nNo DIDs")
 
             else:
                 self.print("No active wallet found.")
@@ -1512,7 +1512,7 @@ class Cli:
                 if name in allAliases:
                     return True, 'alias'
                 if name in allSigners:
-                    return True, 'identifier'
+                    return True, 'DID'
 
                 if checkPersistedFile:
                     toBeWalletFilePath = self.checkIfPersistentWalletExists(origName)
@@ -1675,17 +1675,17 @@ class Cli:
                 self.activeAlias = alias[0] if alias else None
                 self.activeIdentifier = idrOrAlias
             wallet.defaultId = self.activeIdentifier
-            self.print("Current identifier set to {}".
+            self.print("Current DID set to {}".
                        format(self.activeAlias or self.activeIdentifier))
             return True
         return False
 
     def _useIdentifierAction(self, matchedVars):
-        if matchedVars.get('use_id') == 'use identifier':
-            nymOrAlias = matchedVars.get('identifier')
+        if matchedVars.get('use_id') == 'use DID':
+            nymOrAlias = matchedVars.get('DID')
             found = self._setActiveIdentifier(nymOrAlias)
             if not found:
-                self.print("No such identifier found in current wallet")
+                self.print("No such DID found in current wallet")
             return True
 
     def _setPrompt(self, promptText):

--- a/plenum/cli/cli.py
+++ b/plenum/cli/cli.py
@@ -1428,7 +1428,7 @@ class Cli:
                                self._activeWallet is not None and \
                                self._activeWallet.name.lower() == pwn.lower() \
                             else False
-                        activeKeyringMsg = " [Active keyring, may have some unsaved changes]" \
+                        activeKeyringMsg = " [Active wallet, may have some unsaved changes]" \
                             if isThisActiveWallet else ""
                         activeWalletSign = "*  " if isThisActiveWallet \
                             else "   "
@@ -1451,7 +1451,7 @@ class Cli:
     def _listIdsAction(self, matchedVars):
         if matchedVars.get('list_ids') == 'list ids':
             if self._activeWallet:
-                self.print("Active keyring: {}".
+                self.print("Active wallet: {}".
                            format(self._activeWallet.name), newline=False)
                 if self._activeWallet.defaultId:
                     self.print(" (active identifier: {})\n".
@@ -1764,7 +1764,7 @@ class Cli:
                 self._saveActiveWallet()
 
             self._wallets[wallet.name] = wallet
-            self.print('\nSaved keyring "{}" restored'.
+            self.print('\nSaved wallet "{}" restored'.
                        format(wallet.name), newline=False)
             self.print(" ({})".format(walletFilePath)
                        , Token.Gray)
@@ -1877,7 +1877,7 @@ class Cli:
                 if self._activeWallet.getEnvName else "a different"
             currEnvName = " ({})".format(self.getActiveEnv) \
                 if self.getActiveEnv else ""
-            self.print("Active keyring belongs to '{}' environment and can't "
+            self.print("Active wallet belongs to '{}' environment and can't "
                        "be saved to the current environment{}.".
                        format(walletEnvName, currEnvName),
                        Token.BoldOrange)
@@ -1890,7 +1890,7 @@ class Cli:
                 self._activeWallet,
                 getWalletFilePath(contextDir, self.walletFileName))
             if printMsgs:
-                self.print('Active keyring "{}" saved'.format(
+                self.print('Active wallet "{}" saved'.format(
                     self._activeWallet.name), newline=False)
                 self.print(' ({})'.format(walletFilePath), Token.Gray)
 

--- a/plenum/cli/cli.py
+++ b/plenum/cli/cli.py
@@ -88,6 +88,7 @@ from plenum.common.config_util import getConfig
 from plenum.__metadata__ import __version__
 
 
+
 class CustomOutput(Vt100_Output):
     """
     Subclassing Vt100 just to override the `ask_for_cpr` method which prints
@@ -383,14 +384,14 @@ class Cli:
                 'add_key': PhraseWordCompleter('add key'),
                 'for_client': PhraseWordCompleter('for client'),
                 'new_key': PhraseWordCompleter('new key'),
-                'new_keyring': PhraseWordCompleter('new keyring'),
-                'rename_keyring': PhraseWordCompleter('rename keyring'),
+                'new_wallet': PhraseWordCompleter('new keyring'),
+                'rename_wallet': PhraseWordCompleter('rename wallet'),
                 'list_ids': PhraseWordCompleter('list ids'),
-                'list_krs': PhraseWordCompleter('list keyrings'),
+                'list_wallet': PhraseWordCompleter('list wallets'),
                 'become': WordCompleter(['become']),
                 'use_id': PhraseWordCompleter('use identifier'),
-                'use_kr': PhraseWordCompleter('use keyring'),
-                'save_kr': PhraseWordCompleter('save keyring'),
+                'use_wallet': PhraseWordCompleter('use wallet'),
+                'save_wallet': PhraseWordCompleter('save wallet'),
                 'add_gen_txn': PhraseWordCompleter('add genesis transaction'),
                 'prompt': WordCompleter(['prompt']),
                 'create_gen_txn_file': PhraseWordCompleter(
@@ -418,14 +419,14 @@ class Cli:
                 'identifier',
                 'new_key',
                 'list_ids',
-                'list_krs',
+                'list_wallets',
                 'become',
                 'use_id',
                 'prompt',
-                'new_keyring',
-                'use_kr',
-                'save_kr',
-                'rename_keyring',
+                'new_wallet',
+                'use_wallet',
+                'save_wallet',
+                'rename_wallet',
                 'add_genesis',
                 'create_gen_txn_file'
             }
@@ -448,7 +449,7 @@ class Cli:
         return True
 
     def _renameKeyring(self, matchedVars):
-        if matchedVars.get('rename_keyring'):
+        if matchedVars.get('rename_wallet'):
             fromName = matchedVars.get('from')
             toName = matchedVars.get('to')
             conflictFound = self._checkIfIdentifierConflicts(
@@ -457,7 +458,7 @@ class Cli:
                 fromWallet = self.wallets.get(fromName) if fromName \
                     else self.activeWallet
                 if not fromWallet:
-                    self.print('Keyring {} not found'.format(fromName))
+                    self.print('Wallet {} not found'.format(fromName))
                     return True
 
                 if not self._renameWalletFile(fromName, toName):
@@ -467,7 +468,7 @@ class Cli:
                 del self.wallets[fromName]
                 self.wallets[toName] = fromWallet
 
-                self.print('Keyring {} renamed to {}'.format(fromName, toName))
+                self.print('Wallet {} renamed to {}'.format(fromName, toName))
             return True
 
     def _newKeyring(self, matchedVars):
@@ -552,7 +553,7 @@ class Cli:
     def _buildClientIfNotExists(self, config=None):
         if not self._activeClient:
             if not self.activeWallet:
-                print("Keyring is not initialized")
+                print("Wallet is not initialized")
                 return
             # Need a unique name so nodes can differentiate
             name = self.name + randomString(6)
@@ -1090,7 +1091,7 @@ class Cli:
                     self._newWallet(clientName)
                     self.printNoKeyMsg()
                 except NameAlreadyExists:
-                    self.print("Keyring with name {} is not in use, please select it by using 'use keyring {}' command"
+                    self.print("Wallet with name {} is not in use, please select it by using 'use wallet {}' command"
                                .format(clientName, clientName))
 
         else:
@@ -1303,7 +1304,7 @@ class Cli:
             wallet = self._newWallet()
         wallet.addIdentifier(signer=signer)
         if showMsg:
-            self.print("Key created in keyring " + wallet.name)
+            self.print("Key created in wallet " + wallet.name)
 
     def _newSigner(self,
                    wallet=None,
@@ -1372,7 +1373,7 @@ class Cli:
             nm = "{}_{}".format(nm, randomString(5))
 
         if nm in self.wallets:
-            self.print("Keyring {} already exists".format(nm))
+            self.print("Wallet {} already exists".format(nm))
             wallet = self._wallets[nm]
             self.activeWallet = wallet  # type: Wallet
             return wallet
@@ -1387,7 +1388,7 @@ class Cli:
         return wallet
 
     def _listKeyringsAction(self, matchedVars):
-        if matchedVars.get('list_krs') == 'list keyrings':
+        if matchedVars.get('list_wallets') == 'list wallets':
             # TODO move file system related routine to WalletStorageHelper
             keyringBaseDir = self.getKeyringsBaseDir()
             contextDirPath = self.getContextBasedKeyringsBaseDir()
@@ -1444,7 +1445,7 @@ class Cli:
                         self.print("        {}".format(n))
 
             if not anyWalletFound:
-                self.print("No keyrings exists")
+                self.print("No wallets exists")
 
             return True
 
@@ -1472,7 +1473,7 @@ class Cli:
                     self.print("\nNo identifiers")
 
             else:
-                self.print("No active keyring found.")
+                self.print("No active wallet found.")
             return True
 
     def checkIfPersistentWalletExists(self, name, inContextDir=None):
@@ -1507,7 +1508,7 @@ class Cli:
                         allWallets.append(wk.lower())
 
                 if name in allWallets:
-                    return True, 'keyring'
+                    return True, 'wallet'
                 if name in allAliases:
                     return True, 'alias'
                 if name in allSigners:
@@ -1516,7 +1517,7 @@ class Cli:
                 if checkPersistedFile:
                     toBeWalletFilePath = self.checkIfPersistentWalletExists(origName)
                     if toBeWalletFilePath:
-                        return True, 'keyring (stored at: {})'.\
+                        return True, 'wallet (stored at: {})'.\
                             format(toBeWalletFilePath)
 
                 return False, None
@@ -1580,8 +1581,8 @@ class Cli:
         keyringsBaseDir = self.getKeyringsBaseDir()
         baseWalletDirName = dirname(filePath)
         if not self._isWalletFilePathBelongsToCurrentContext(filePath):
-            self.print("\nKeyring base directory is: {}"
-                       "\nGiven keyring file {} "
+            self.print("\nWallet base directory is: {}"
+                       "\nGiven wallet file {} "
                        "should be in one of it's sub directories "
                        "(you can create it if it doesn't exists) "
                        "according to the environment it belongs to."
@@ -1612,7 +1613,7 @@ class Cli:
 
     def _searchAndSetWallet(self, name, copyAs=None, override=False):
         if self._activeWallet and self._activeWallet.name.lower() == name.lower():
-            self.print("Keyring already in use.")
+            self.print("Wallet already in use.")
             return True
 
         if os.path.isabs(name) and os.path.exists(name):
@@ -1625,12 +1626,12 @@ class Cli:
                 self._saveActiveWallet()
                 self.activeWallet = wallet
             if not wallet:
-                self.print("No such keyring found in current context.")
+                self.print("No such wallet found in current context.")
         return True
 
     def _saveKeyringAction(self, matchedVars):
-        if matchedVars.get('save_kr') == 'save keyring':
-            name = matchedVars.get('keyring')
+        if matchedVars.get('save_wallet') == 'save wallet':
+            name = matchedVars.get('wallet')
             if not self._activeWallet:
                 self.print("No active wallet to be saved.\n")
                 return True
@@ -1638,10 +1639,10 @@ class Cli:
             if name:
                 wallet = self._getWalletByName(name)
                 if not wallet:
-                    self.print("No such keyring loaded or exists.")
+                    self.print("No such wallet loaded or exists.")
                     return True
                 elif wallet.name != self._activeWallet.name:
-                    self.print("Given keyring is not active "
+                    self.print("Given wallet is not active "
                                "and it must be already saved.")
                     return True
 
@@ -1649,8 +1650,8 @@ class Cli:
             return True
 
     def _useKeyringAction(self, matchedVars):
-        if matchedVars.get('use_kr') == 'use keyring':
-            name = matchedVars.get('keyring')
+        if matchedVars.get('use_wallet') == 'use wallet':
+            name = matchedVars.get('wallet')
             override = True if matchedVars.get('override') else False
             copyAs = matchedVars.get('copy_as_name')
             self._searchAndSetWallet(name, copyAs=copyAs, override=override)
@@ -1684,7 +1685,7 @@ class Cli:
             nymOrAlias = matchedVars.get('identifier')
             found = self._setActiveIdentifier(nymOrAlias)
             if not found:
-                self.print("No such identifier found in current keyring")
+                self.print("No such identifier found in current wallet")
             return True
 
     def _setPrompt(self, promptText):
@@ -1712,16 +1713,16 @@ class Cli:
 
     @property
     def getWalletContextMistmatchMsg(self):
-        return "The active keyring '{}' doesn't belong to current " \
+        return "The active wallet '{}' doesn't belong to current " \
                "environment. \nBefore you perform any transaction signing, " \
-               "please create or activate compatible keyring.".\
+               "please create or activate compatible wallet.".\
             format(self._activeWallet.name)
 
     def printWarningIfIncompatibleWalletIsRestored(self, walletFilePath):
         if not self.checkIfWalletBelongsToCurrentContext(self._activeWallet) \
                 or not self._isWalletFilePathBelongsToCurrentContext(walletFilePath):
             self.print(self.getWalletContextMistmatchMsg)
-            self.print("Any changes made to this keyring won't be persisted.",
+            self.print("Any changes made to this wallet won't be persisted.",
                        Token.BoldOrange)
 
     def performValidationCheck(self, wallet, walletFilePath, override=False):
@@ -1735,12 +1736,12 @@ class Cli:
 
         if conflictFound and not override:
             self.print(
-                "A keyring with given name already loaded, "
+                "A wallet with given name already loaded, "
                 "here are few options:\n"
-                "1. If you still want to load given persisted keyring at the "
-                "risk of overriding the already loaded keyring, then add this "
+                "1. If you still want to load given persisted wallet at the "
+                "risk of overriding the already loaded wallet, then add this "
                 "clause to same command and retry: override\n"
-                "2. If you want to create a copy of persisted keyring with "
+                "2. If you want to create a copy of persisted wallet with "
                 "different name, then, add this clause to "
                 "same command and retry: copy-as <new-wallet-name>")
             return False
@@ -1779,7 +1780,7 @@ class Cli:
                 "error occurred while restoring wallet {}: {}".
                     format(walletFilePath, e), Token.BoldOrange)
         except IOError as e:
-            self.logger.debug("No such keyring file exists ({})".
+            self.logger.debug("No such wallet file exists ({})".
                               format(walletFilePath))
 
     def restoreLastActiveWallet(self):
@@ -1976,7 +1977,7 @@ class Cli:
         return True
 
     def printNoKeyMsg(self):
-        self.print("No key present in keyring")
+        self.print("No key present in wallet")
         self.printUsage(("new key [with seed <32 byte string>]", ))
 
     def printUsage(self, msgs):

--- a/plenum/cli/cli.py
+++ b/plenum/cli/cli.py
@@ -594,7 +594,7 @@ class Cli:
     @activeWallet.setter
     def activeWallet(self, wallet):
         self._activeWallet = wallet
-        self.print('Active keyring set to "{}"'.format(wallet.name))
+        self.print('Active wallet set to "{}"'.format(wallet.name))
 
     @property
     def activeClient(self):
@@ -1378,7 +1378,7 @@ class Cli:
             return wallet
         wallet = self._buildWalletClass(nm)
         self._wallets[nm] = wallet
-        self.print("New keyring {} created".format(nm))
+        self.print("New wallet {} created".format(nm))
         self.activeWallet = wallet
         # TODO when the command is implemented
         # if nm == self.defaultWalletName:

--- a/plenum/cli/command.py
+++ b/plenum/cli/command.py
@@ -117,16 +117,16 @@ newKeyCmd = Command(
 
 listIdsCmd = Command(
     id="list ids",
-    title="Lists all identifiers of active wallet",
+    title="Lists all DIDs of active wallet",
     usage="list ids [with verkeys]",
     examples=["list ids", "list ids with verkeys"])
 
 useIdCmd = Command(
-    id="use identifier",
-    title="Marks given identifier active/default",
-    usage="use identifier <identifier>",
-    note="Note: To see all identifiers in active wallet, use 'list ids' command",
-    examples="use identifier 5pJcAEAQqW7B8aGSxDArGaeXvb1G1MQwwqLMLmG2fAy9")
+    id="use DID",
+    title="Marks given DID active/default",
+    usage="use DID <identifier>",
+    note="Note: To see all DIDs in active wallet, use 'list ids' command",
+    examples="use DID 5pJcAEAQqW7B8aGSxDArGaeXvb1G1MQwwqLMLmG2fAy9")
 
 addGenesisTxnCmd = Command(
     id="add genesis transaction",

--- a/plenum/cli/command.py
+++ b/plenum/cli/command.py
@@ -117,7 +117,7 @@ newKeyCmd = Command(
 
 listIdsCmd = Command(
     id="list ids",
-    title="Lists all identifiers of active keyring",
+    title="Lists all identifiers of active wallet",
     usage="list ids [with verkeys]",
     examples=["list ids", "list ids with verkeys"])
 
@@ -125,7 +125,7 @@ useIdCmd = Command(
     id="use identifier",
     title="Marks given identifier active/default",
     usage="use identifier <identifier>",
-    note="Note: To see all identifiers in active keyring, use 'list ids' command",
+    note="Note: To see all identifiers in active wallet, use 'list ids' command",
     examples="use identifier 5pJcAEAQqW7B8aGSxDArGaeXvb1G1MQwwqLMLmG2fAy9")
 
 addGenesisTxnCmd = Command(
@@ -153,30 +153,30 @@ changePromptCmd = Command(
     examples="prompt Alice")
 
 newKeyringCmd = Command(
-    id="new keyring",
-    title="Creates new keyring",
-    usage="new keyring <name>",
-    examples="new keyring mykeyring")
+    id="new wallet",
+    title="Creates new wallet",
+    usage="new wallet <name>",
+    examples="new wallet mywallet")
 
 useKeyringCmd = Command(
-    id="use keyring",
-    title="Loads given keyring and marks it active/default",
-    usage="use keyring <name|absolute-wallet-file-path>",
-    examples=["use keyring mykeyring", "use keyring /home/ubuntu/.sovrin/keyrings/test/mykeyring.wallet"])
+    id="use wallet",
+    title="Loads given wallet and marks it active/default",
+    usage="use wallet <name|absolute-wallet-file-path>",
+    examples=["use wallet mywallet", "use wallet /home/ubuntu/.sovrin/keyrings/test/mywallet.wallet"])
 
 saveKeyringCmd = Command(
-    id="save keyring",
-    title="Saves active keyring",
-    usage="save keyring [<active-keyring-name>]",
-    examples=["save keyring", "save keyring mykeyring"])
+    id="save wallet",
+    title="Saves active wallet",
+    usage="save wallet [<active-keyring-name>]",
+    examples=["save wallet", "save wallet mywallet"])
 
 renameKeyringCmd = Command(
-    id="rename keyring",
-    title="Renames given keyring",
-    usage="rename keyring <old-name> to <new-name>",
-    examples="rename keyring mykeyring to yourkeyring")
+    id="rename wallet",
+    title="Renames given wallet",
+    usage="rename wallet <old-name> to <new-name>",
+    examples="rename wallet mywallet to yourwallet")
 
 listKeyringCmd = Command(
-    id="list keyrings",
-    title="Lists all keyrings",
-    usage="list keyrings")
+    id="list wallets",
+    title="Lists all wallets",
+    usage="list wallets")

--- a/plenum/cli/command.py
+++ b/plenum/cli/command.py
@@ -107,7 +107,7 @@ clientShowCmd = Command(
 
 newKeyCmd = Command(
     id="new key",
-    title="Adds new key to active keyring",
+    title="Adds new key to active wallet",
     usage="new key [with seed <32 character seed>] [[as] <alias>]",
     examples=[
         "new key",

--- a/plenum/cli/constants.py
+++ b/plenum/cli/constants.py
@@ -59,7 +59,7 @@ CLIENT_GRAMS_NEW_KEYPAIR_REG_EX = \
     "\s*) "
 
 CLIENT_GRAMS_NEW_KEYRING_REG_EX = \
-    "(\s* (?P<new_keyring>new\skeyring) \s+ (?P<name>[a-zA-Z0-9]+))\s*"
+    "(\s* (?P<new_wallet>new\swallet) \s+ (?P<name>[a-zA-Z0-9]+))\s*"
 
 CLIENT_GRAMS_RENAME_KEYRING_REG_EX = \
     "(\s*(?P<rename_keyring>rename\s+keyring)" \

--- a/plenum/cli/constants.py
+++ b/plenum/cli/constants.py
@@ -62,7 +62,7 @@ CLIENT_GRAMS_NEW_KEYRING_REG_EX = \
     "(\s* (?P<new_wallet>new\swallet) \s+ (?P<name>[a-zA-Z0-9]+))\s*"
 
 CLIENT_GRAMS_RENAME_KEYRING_REG_EX = \
-    "(\s*(?P<rename_keyring>rename\s+keyring)" \
+    "(\s*(?P<rename_wallet>rename\s+wallet)" \
     "\s? (\s+(?P<from>[A-Za-z0-9+=/]*))?" \
     "\s+ (to\s+(?P<to>[A-Za-z0-9+=/]*))" \
     "\s*) "
@@ -70,7 +70,7 @@ CLIENT_GRAMS_RENAME_KEYRING_REG_EX = \
 CLIENT_GRAMS_LIST_IDS_REG_EX = "(\s* (?P<list_ids>list\sids) " \
                                "\s?(?P<with_verkeys>with\s+verkeys)? \s*) "
 
-CLIENT_GRAMS_LIST_KEYRINGS_REG_EX = "(\s* (?P<list_krs>list\skeyrings) \s*) "
+CLIENT_GRAMS_LIST_KEYRINGS_REG_EX = "(\s* (?P<list_wallets>list\swallets) \s*) "
 
 CLIENT_GRAMS_BECOME_REG_EX = "(\s* (?P<become>become) " \
                              "\s+ (?P<id>[a-zA-Z0-9]+) \s*) "
@@ -78,15 +78,15 @@ CLIENT_GRAMS_BECOME_REG_EX = "(\s* (?P<become>become) " \
 CLIENT_GRAMS_USE_KEYPAIR_REG_EX = "(\s* (?P<use_id>use\s+identifier) " \
                                   "\s+ (?P<identifier>[A-Za-z0-9+=/]*) \s*) "
 
-CLIENT_GRAMS_USE_KEYRING_REG_EX = "(\s* (?P<use_kr>use\s+keyring) " \
-                                  "\s+ (?P<keyring>[A-Za-z0-9+-_=/]*) \s*" \
+CLIENT_GRAMS_USE_KEYRING_REG_EX = "(\s* (?P<use_wallet>use\s+wallet) " \
+                                  "\s+ (?P<wallet>[A-Za-z0-9+-_=/]*) \s*" \
                                   "\s? ((?P<copy_as>copy\sas)\s" \
                                   "(?P<copy_as_name>[A-Za-z0-9+-_=/]+)?)? \s*" \
                                   "\s? (?P<override>override)? " \
                                   "\s*)"
 
-CLIENT_GRAMS_SAVE_KEYRING_REG_EX = "(\s* (?P<save_kr>save\s+keyring)" \
-                                  "\s? (?P<keyring>[A-Za-z0-9+-_=/]+)? \s*)"
+CLIENT_GRAMS_SAVE_KEYRING_REG_EX = "(\s* (?P<save_wallet>save\s+wallet)" \
+                                  "\s? (?P<wallet>[A-Za-z0-9+-_=/]+)? \s*)"
 
 CLIENT_GRAMS_ADD_GENESIS_TXN_REG_EX = \
     "(\s*(?P<add_gen_txn>add \s+ genesis \s+ transaction)" \

--- a/plenum/cli/constants.py
+++ b/plenum/cli/constants.py
@@ -51,7 +51,7 @@ CLIENT_GRAMS_CLIENT_SHOW_REG_EX = \
     "\s+ (?P<cli_action>show) \s+ (?P<req_id>[0-9]+) \s*) "
 CLIENT_GRAMS_ADD_KEY_REG_EX = \
     "(\s* (?P<add_key>add\s+key) \s+ (?P<verkey>[a-fA-F0-9]+) " \
-    "\s+ (?P<for_client>for\s+client) \s+ (?P<identifier>[a-zA-Z0-9]+) \s*) "
+    "\s+ (?P<for_client>for\s+client) \s+ (?P<DID>[a-zA-Z0-9]+) \s*) "
 CLIENT_GRAMS_NEW_KEYPAIR_REG_EX = \
     "(\s* (?P<new_key>new\skey) \s*" \
     "\s? (with\s+seed\s+(?P<seed>[a-zA-Z0-9]+))?" \
@@ -75,8 +75,8 @@ CLIENT_GRAMS_LIST_KEYRINGS_REG_EX = "(\s* (?P<list_wallets>list\swallets) \s*) "
 CLIENT_GRAMS_BECOME_REG_EX = "(\s* (?P<become>become) " \
                              "\s+ (?P<id>[a-zA-Z0-9]+) \s*) "
 
-CLIENT_GRAMS_USE_KEYPAIR_REG_EX = "(\s* (?P<use_id>use\s+identifier) " \
-                                  "\s+ (?P<identifier>[A-Za-z0-9+=/]*) \s*) "
+CLIENT_GRAMS_USE_KEYPAIR_REG_EX = "(\s* (?P<use_id>use\s+DID) " \
+                                  "\s+ (?P<DID>[A-Za-z0-9+=/]*) \s*) "
 
 CLIENT_GRAMS_USE_KEYRING_REG_EX = "(\s* (?P<use_wallet>use\s+wallet) " \
                                   "\s+ (?P<wallet>[A-Za-z0-9+-_=/]*) \s*" \
@@ -92,7 +92,7 @@ CLIENT_GRAMS_ADD_GENESIS_TXN_REG_EX = \
     "(\s*(?P<add_gen_txn>add \s+ genesis \s+ transaction)" \
     "\s+ (?P<type>[a-zA-Z0-9_]+)" \
     "\s+ (for\s+(?P<dest>[A-Za-z0-9+=/]+))?" \
-    "\s? (by\s+(?P<identifier>[A-Za-z0-9+=/]*))?" \
+    "\s? (by\s+(?P<DID>[A-Za-z0-9+=/]*))?" \
     "\s? (with\s+data\s+(?P<data>\{{\s*.*\}}))?" \
     "\s? (role\s*=\s*(?P<role>{role}))?" \
     "\s*) ".format(role=Roles.STEWARD.name)

--- a/plenum/cli/constants.py
+++ b/plenum/cli/constants.py
@@ -92,7 +92,7 @@ CLIENT_GRAMS_ADD_GENESIS_TXN_REG_EX = \
     "(\s*(?P<add_gen_txn>add \s+ genesis \s+ transaction)" \
     "\s+ (?P<type>[a-zA-Z0-9_]+)" \
     "\s+ (for\s+(?P<dest>[A-Za-z0-9+=/]+))?" \
-    "\s? (by\s+(?P<DID>[A-Za-z0-9+=/]*))?" \
+    "\s? (by\s+(?P<identifier>[A-Za-z0-9+=/]*))?" \
     "\s? (with\s+data\s+(?P<data>\{{\s*.*\}}))?" \
     "\s? (role\s*=\s*(?P<role>{role}))?" \
     "\s*) ".format(role=Roles.STEWARD.name)

--- a/plenum/test/cli/helper.py
+++ b/plenum/test/cli/helper.py
@@ -594,7 +594,7 @@ def checkPermissions(path, mode):
 def checkWalletRestored(cli, expectedWalletKeyName,
                        expectedIdentifiers):
 
-    cli.lastCmdOutput == "Saved keyring {} restored".format(
+    cli.lastCmdOutput == "Saved wallet {} restored".format(
         expectedWalletKeyName)
     assert cli._activeWallet.name == expectedWalletKeyName
     assert len(cli._activeWallet.identifiers) == \
@@ -635,7 +635,7 @@ def useAndAssertKeyring(do, name, expectedName=None, expectedMsgs=None):
 def saveAndAssertKeyring(do, name, expectedName=None, expectedMsgs=None):
     keyringName = expectedName or name
     finalExpectedMsgs = expectedMsgs or \
-                        ['Active keyring "{}" saved'.format(keyringName)]
+                        ['Active wallet "{}" saved'.format(keyringName)]
     do('save keyring'.format(name),
        expect=finalExpectedMsgs
     )
@@ -650,8 +650,8 @@ def exitFromCli(do):
 def restartCliAndAssert(cli, do, expectedRestoredWalletName,
                expectedIdentifiers):
     do(None, expect=[
-        'Saved keyring "{}" restored'.format(expectedRestoredWalletName),
-        'Active keyring set to "{}"'.format(expectedRestoredWalletName)
+        'Saved wallet "{}" restored'.format(expectedRestoredWalletName),
+        'Active wallet set to "{}"'.format(expectedRestoredWalletName)
     ], within=5)
     assert cli._activeWallet is not None
     assert len(cli._activeWallet.identifiers) == expectedIdentifiers

--- a/plenum/test/cli/helper.py
+++ b/plenum/test/cli/helper.py
@@ -259,7 +259,7 @@ def checkRequest(cli, operation):
     createNewKeyring(cName, cli)
 
     cli.enterCmd("new key {}".format("testkey1"))
-    assert 'Key created in keyring {}'.format(cName) in cli.lastCmdOutput
+    assert 'Key created in wallet {}'.format(cName) in cli.lastCmdOutput
 
     cli.enterCmd('client {} send {}'.format(cName, operation))
     client = cli.clients[cName]
@@ -341,7 +341,7 @@ def newKeyPair(cli: TestCli, alias: str=None):
     checkCmdValid(cli, cmd)
     assert len(cli.activeWallet.idsToSigners.keys()) == len(idrs) + 1
     new_identifer = set(cli.activeWallet.idsToSigners.keys()).difference(idrs).pop()
-    expected = ['Key created in keyring Default']
+    expected = ['Key created in wallet Default']
     if alias:
         idr = cli.activeWallet.aliasesToIds.get(alias)
         verkey = cli.activeWallet.getVerkey(idr)
@@ -611,7 +611,7 @@ def getOldIdentifiersForActiveWallet(cli):
 def createAndAssertNewCreation(do, cli, keyringName):
     oldIdentifiers = getOldIdentifiersForActiveWallet(cli)
     do('new key', within=2,
-       expect=["Key created in keyring {}".format(keyringName)])
+       expect=["Key created in wallet {}".format(keyringName)])
     assert len(cli._activeWallet.identifiers) == oldIdentifiers + 1
 
 
@@ -627,7 +627,7 @@ def useAndAssertKeyring(do, name, expectedName=None, expectedMsgs=None):
     keyringName = expectedName or name
     finalExpectedMsgs = expectedMsgs or \
                         ['Active wallet set to "{}"'.format(keyringName)]
-    do('use keyring {}'.format(name),
+    do('use wallet {}'.format(name),
        expect=finalExpectedMsgs
     )
 
@@ -636,7 +636,7 @@ def saveAndAssertKeyring(do, name, expectedName=None, expectedMsgs=None):
     keyringName = expectedName or name
     finalExpectedMsgs = expectedMsgs or \
                         ['Active wallet "{}" saved'.format(keyringName)]
-    do('save keyring'.format(name),
+    do('save wallet'.format(name),
        expect=finalExpectedMsgs
     )
 

--- a/plenum/test/cli/helper.py
+++ b/plenum/test/cli/helper.py
@@ -617,16 +617,16 @@ def createAndAssertNewCreation(do, cli, keyringName):
 
 def createAndAssertNewKeyringCreation(do, name, expectedMsgs=None):
     finalExpectedMsgs = expectedMsgs if expectedMsgs else [
-           'Active keyring set to "{}"'.format(name),
-           'New keyring {} created'.format(name)
+           'Active wallet set to "{}"'.format(name),
+           'New wallet {} created'.format(name)
         ]
-    do('new keyring {}'.format(name), expect=finalExpectedMsgs)
+    do('new wallet {}'.format(name), expect=finalExpectedMsgs)
 
 
 def useAndAssertKeyring(do, name, expectedName=None, expectedMsgs=None):
     keyringName = expectedName or name
     finalExpectedMsgs = expectedMsgs or \
-                        ['Active keyring set to "{}"'.format(keyringName)]
+                        ['Active wallet set to "{}"'.format(keyringName)]
     do('use keyring {}'.format(name),
        expect=finalExpectedMsgs
     )

--- a/plenum/test/cli/helper.py
+++ b/plenum/test/cli/helper.py
@@ -345,16 +345,16 @@ def newKeyPair(cli: TestCli, alias: str=None):
     if alias:
         idr = cli.activeWallet.aliasesToIds.get(alias)
         verkey = cli.activeWallet.getVerkey(idr)
-        expected.append('Identifier for key is {}'.
+        expected.append('DID for key is {}'.
                         format(idr))
         expected.append('Verification key is {}'.format(verkey))
-        expected.append('Alias for identifier is {}'.format(alias))
+        expected.append('Alias for DID is {}'.format(alias))
     else:
-        expected.append('Identifier for key is {}'.format(new_identifer))
+        expected.append('DID for key is {}'.format(new_identifer))
         verkey = cli.activeWallet.getVerkey(new_identifer)
         expected.append('Verification key is {}'.format(verkey))
 
-    expected.append('Current identifier set to {}'.format(alias or new_identifer))
+    expected.append('Current DID set to {}'.format(alias or new_identifer))
 
     # TODO: Reconsider this
     # Using `in` rather than `=` so as to take care of the fact that this might

--- a/plenum/test/cli/test_basic_node_commands.py
+++ b/plenum/test/cli/test_basic_node_commands.py
@@ -49,5 +49,5 @@ def testCreateNodeWhenClientExistsWithKey(be, do, cli, validNodeNames):
     clientName = "testc2"
     be(cli)
     do("new client {}".format(clientName), expect=["Active client set to {}".format(clientName)])
-    do("new key", expect=["Current identifier set to "])
+    do("new key", expect=["Current DID set to "])
     addNodes(be, do, cli, validNodeNames)

--- a/plenum/test/cli/test_basic_node_commands.py
+++ b/plenum/test/cli/test_basic_node_commands.py
@@ -42,7 +42,7 @@ def testCreateNodeWhenClientExistsWithoutKey(be, do, cli, validNodeNames):
     clientName = "testc1"
     be(cli)
     do("new client {}".format(clientName), expect=["Active client set to {}".format(clientName)])
-    do("new node {}".format(validNodeNames[0]), expect=["No key present in keyring"], within=2)
+    do("new node {}".format(validNodeNames[0]), expect=["No key present in wallet"], within=2)
 
 
 def testCreateNodeWhenClientExistsWithKey(be, do, cli, validNodeNames):

--- a/plenum/test/cli/test_cli_startup.py
+++ b/plenum/test/cli/test_cli_startup.py
@@ -26,7 +26,7 @@ def initStatements(cli):
     return ["New wallet {} created".format(name),
             "Current wallet set to " + name,
             "Key created in wallet " + name,
-            "Identifier for key is " + cryptonym,
+            "DID for key is " + cryptonym,
             "Current identifier set to " + cryptonym,
             "Note: To rename this wallet, use following command:",
             "    rename wallet Default to NewName"]

--- a/plenum/test/cli/test_command_reg_ex.py
+++ b/plenum/test/cli/test_command_reg_ex.py
@@ -80,10 +80,10 @@ def testListKeyringsCommandRegEx(grammar):
 
 
 def testNewKeyRingCommandRegEx(grammar):
-    matchedVars = getMatchedVariables(grammar, "new keyring MyKey1")
-    assertCliTokens(matchedVars, {"new_keyring": "new keyring", "name": "MyKey1"})
-    matchedVars = getMatchedVariables(grammar, "new keyring MyKey1 ")
-    assertCliTokens(matchedVars, {"new_keyring": "new keyring", "name": "MyKey1"})
+    matchedVars = getMatchedVariables(grammar, "new wallet MyKey1")
+    assertCliTokens(matchedVars, {"new_wallet": "new wallet", "name": "MyKey1"})
+    matchedVars = getMatchedVariables(grammar, "new wallet MyKey1 ")
+    assertCliTokens(matchedVars, {"new_wallet": "new wallet", "name": "MyKey1"})
 
 
 def testRenameKeyRingCommandRegEx(grammar):

--- a/plenum/test/cli/test_command_reg_ex.py
+++ b/plenum/test/cli/test_command_reg_ex.py
@@ -33,38 +33,38 @@ def testListRegEx(grammar):
 
 
 def testUseKeyringRegEx(grammar):
-    matchedVars = getMatchedVariables(grammar, "use keyring abc")
-    assertCliTokens(matchedVars, {"use_kr": "use keyring",
-                                  "keyring": "abc", "copy_as": None,
+    matchedVars = getMatchedVariables(grammar, "use wallet abc")
+    assertCliTokens(matchedVars, {"use_wallet": "use wallet",
+                                  "wallet": "abc", "copy_as": None,
                                   "copy-as-name": None, "override": None})
-    matchedVars = getMatchedVariables(grammar, "use keyring abc ")
-    assertCliTokens(matchedVars, {"use_kr": "use keyring", "keyring": "abc",
+    matchedVars = getMatchedVariables(grammar, "use wallet abc ")
+    assertCliTokens(matchedVars, {"use_wallet": "use wallet", "wallet": "abc",
                                   "copy_as": None, "copy_as_name": None,
                                   "override": None})
 
-    matchedVars = getMatchedVariables(grammar, "use keyring abc copy as newkr")
-    assertCliTokens(matchedVars, {"use_kr": "use keyring", "keyring": "abc",
-                                  "copy_as": "copy as", "copy_as_name": "newkr",
+    matchedVars = getMatchedVariables(grammar, "use wallet abc copy as newwallet")
+    assertCliTokens(matchedVars, {"use_wallet": "use wallet", "wallet": "abc",
+                                  "copy_as": "copy as", "copy_as_name": "newwallet",
                                   "override": None})
 
-    matchedVars = getMatchedVariables(grammar, "use keyring abc copy as newkr "
+    matchedVars = getMatchedVariables(grammar, "use wallet abc copy as newwallet "
                                                "override")
-    assertCliTokens(matchedVars, {"use_kr": "use keyring", "keyring": "abc",
-                                  "copy_as": "copy as", "copy_as_name": "newkr",
+    assertCliTokens(matchedVars, {"use_wallet": "use wallet", "wallet": "abc",
+                                  "copy_as": "copy as", "copy_as_name": "newwallet",
                                   "override": "override"})
 
-    matchedVars = getMatchedVariables(grammar, "use keyring abc override")
-    assertCliTokens(matchedVars, {"use_kr": "use keyring", "keyring": "abc",
+    matchedVars = getMatchedVariables(grammar, "use wallet abc override")
+    assertCliTokens(matchedVars, {"use_wallet": "use wallet", "wallet": "abc",
                                   "copy_as": None, "copy_as_name": None,
                                   "override": "override"})
 
 
 def testSaveKeyringRegEx(grammar):
-    matchedVars = getMatchedVariables(grammar, "save keyring")
-    assertCliTokens(matchedVars, {"save_kr": "save keyring", "keyring": None})
-    matchedVars = getMatchedVariables(grammar, "save keyring default")
-    assertCliTokens(matchedVars, {"save_kr": "save keyring",
-                                  "keyring": "default"})
+    matchedVars = getMatchedVariables(grammar, "save wallet")
+    assertCliTokens(matchedVars, {"save_wallet": "save wallet", "wallet": None})
+    matchedVars = getMatchedVariables(grammar, "save wallet default")
+    assertCliTokens(matchedVars, {"save_wallet": "save wallet",
+                                  "wallet": "default"})
 
 
 def testPromptCommandRegEx(grammar):
@@ -75,8 +75,8 @@ def testPromptCommandRegEx(grammar):
 
 
 def testListKeyringsCommandRegEx(grammar):
-    matchedVars = getMatchedVariables(grammar, "list keyrings")
-    assertCliTokens(matchedVars, {"list_krs": "list keyrings"})
+    matchedVars = getMatchedVariables(grammar, "list wallets")
+    assertCliTokens(matchedVars, {"list_wallets": "list wallets"})
 
 
 def testNewKeyRingCommandRegEx(grammar):
@@ -87,10 +87,10 @@ def testNewKeyRingCommandRegEx(grammar):
 
 
 def testRenameKeyRingCommandRegEx(grammar):
-    matchedVars = getMatchedVariables(grammar, "rename keyring MyKey1 to MyKey2")
-    assertCliTokens(matchedVars, {"rename_keyring": "rename keyring", "from": "MyKey1", "to": "MyKey2"})
-    matchedVars = getMatchedVariables(grammar, "rename keyring to MyKey2")
-    assertCliTokens(matchedVars, {"rename_keyring": "rename keyring", "from": None, "to": "MyKey2"})
+    matchedVars = getMatchedVariables(grammar, "rename wallet MyKey1 to MyKey2")
+    assertCliTokens(matchedVars, {"rename_wallet": "rename wallet", "from": "MyKey1", "to": "MyKey2"})
+    matchedVars = getMatchedVariables(grammar, "rename wallet to MyKey2")
+    assertCliTokens(matchedVars, {"rename_wallet": "rename wallet", "from": None, "to": "MyKey2"})
 
 
 def testNewKeypairCommandRegEx(grammar):

--- a/plenum/test/cli/test_help_command.py
+++ b/plenum/test/cli/test_help_command.py
@@ -22,7 +22,7 @@ def testNewKey(cli):
     cli.enterCmd("help new key")
     newMsg = """new key
 -------
-     title: Adds new key to active keyring
+     title: Adds new key to active wallet
 
      usage: new key [with seed <32 character seed>] [[as] <alias>]
 

--- a/plenum/test/cli/test_key_pair.py
+++ b/plenum/test/cli/test_key_pair.py
@@ -14,7 +14,7 @@ def testKeyPair(cli, pubKey):
 
 
 def testUseKeyPair(cli, pubKey):
-    cli.enterCmd('use identifier {}'.format("test"))
+    cli.enterCmd('use DID {}'.format("test"))
     assert cli.activeAlias == "test"
 
 

--- a/plenum/test/cli/test_keyring.py
+++ b/plenum/test/cli/test_keyring.py
@@ -16,10 +16,10 @@ def testNewKeyring(cli):
 
 def renameKeyring(oldName, newName, cli):
     if oldName:
-        cli.enterCmd("rename keyring {} to {}".format(oldName, newName))
+        cli.enterCmd("rename wallet {} to {}".format(oldName, newName))
     else:
-        cli.enterCmd("rename keyring to {}".format(newName))
-    assert 'Keyring {} renamed to {}'.format(oldName,
+        cli.enterCmd("rename wallet to {}".format(newName))
+    assert 'Wallet {} renamed to {}'.format(oldName,
                                             newName) in cli.lastCmdOutput
     assert cli._activeWallet.name == newName
     assert len(cli.activeWallet.identifiers) == 0
@@ -27,10 +27,10 @@ def renameKeyring(oldName, newName, cli):
 
 def renameToExistingKeyring(oldName, newName, cli):
     if oldName:
-        cli.enterCmd("rename keyring {} to {}".format(oldName, newName))
+        cli.enterCmd("rename wallet {} to {}".format(oldName, newName))
     else:
-        cli.enterCmd("rename keyring to {}".format(newName))
-    assert '"{}" conflicts with an existing keyring. ' \
+        cli.enterCmd("rename wallet to {}".format(newName))
+    assert '"{}" conflicts with an existing wallet. ' \
            'Please choose a new name'.format(newName) in \
            cli.lastCmdOutput
 
@@ -47,30 +47,30 @@ def testKeyAndKeyRing(cli):
     cli.enterCmd("new wallet {}".format(keyring1))
     assert 'Active wallet set to "{}"'.format(keyring1) in cli.lastCmdOutput
     assert 'New wallet {} created'.format(keyring1) in cli.lastCmdOutput
-    cli.enterCmd("list keyrings")
+    cli.enterCmd("list wallets")
     assert 'testkr1' in cli.lastCmdOutput
 
     cli.enterCmd("new key {}".format(keyring1))
-    assert 'Key created in keyring {}'.format(keyring1) in cli.lastCmdOutput
+    assert 'Key created in wallet {}'.format(keyring1) in cli.lastCmdOutput
 
     cli.enterCmd("new key {}".format(keyring1))
-    assert 'Key created in keyring {}'.format(keyring1) in cli.lastCmdOutput
+    assert 'Key created in wallet {}'.format(keyring1) in cli.lastCmdOutput
 
     key1 = "testkey1"
     cli.enterCmd("new key {}".format(key1))
-    assert 'Key created in keyring {}'.format(keyring1) in cli.lastCmdOutput
+    assert 'Key created in wallet {}'.format(keyring1) in cli.lastCmdOutput
 
     cli.enterCmd("new wallet {}".format(key1))
     assert 'Active wallet set to "{}"'.format(key1) in cli.lastCmdOutput
     assert 'New wallet {} created'.format(key1) in cli.lastCmdOutput
-    cli.enterCmd("list keyrings")
+    cli.enterCmd("list wallets")
     assert 'testkey1' in cli.lastCmdOutput
 
     cli.enterCmd("use identifier {}".format(key1))
-    assert 'No such identifier found in current keyring' in cli.lastCmdOutput
+    assert 'No such identifier found in current wallet' in cli.lastCmdOutput
 
     cli.enterCmd("use identifier {}".format(keyring1))
-    assert 'No such identifier found in current keyring' in cli.lastCmdOutput
+    assert 'No such identifier found in current wallet' in cli.lastCmdOutput
 
     keyring2 = "testkr2"
     cli.enterCmd("new wallet {}".format(keyring2))
@@ -78,9 +78,9 @@ def testKeyAndKeyRing(cli):
     assert 'New wallet {} created'.format(keyring2) in cli.lastCmdOutput
 
     cli.enterCmd("use identifier {}".format(key1))
-    assert 'No such identifier found in current keyring' in cli.lastCmdOutput
+    assert 'No such identifier found in current wallet' in cli.lastCmdOutput
 
-    cli.enterCmd("use keyring {}".format(keyring1))
+    cli.enterCmd("use wallet {}".format(keyring1))
     assert 'Active wallet set to "{}"'.format(keyring1) in cli.lastCmdOutput
 
     cli.enterCmd("use identifier {}".format(key1))

--- a/plenum/test/cli/test_keyring.py
+++ b/plenum/test/cli/test_keyring.py
@@ -66,22 +66,22 @@ def testKeyAndKeyRing(cli):
     cli.enterCmd("list wallets")
     assert 'testkey1' in cli.lastCmdOutput
 
-    cli.enterCmd("use identifier {}".format(key1))
-    assert 'No such identifier found in current wallet' in cli.lastCmdOutput
+    cli.enterCmd("use DID {}".format(key1))
+    assert 'No such DID found in current wallet' in cli.lastCmdOutput
 
-    cli.enterCmd("use identifier {}".format(keyring1))
-    assert 'No such identifier found in current wallet' in cli.lastCmdOutput
+    cli.enterCmd("use DID {}".format(keyring1))
+    assert 'No such DID found in current wallet' in cli.lastCmdOutput
 
     keyring2 = "testkr2"
     cli.enterCmd("new wallet {}".format(keyring2))
     assert 'Active wallet set to "{}"'.format(keyring2) in cli.lastCmdOutput
     assert 'New wallet {} created'.format(keyring2) in cli.lastCmdOutput
 
-    cli.enterCmd("use identifier {}".format(key1))
-    assert 'No such identifier found in current wallet' in cli.lastCmdOutput
+    cli.enterCmd("use DID {}".format(key1))
+    assert 'No such DID found in current wallet' in cli.lastCmdOutput
 
     cli.enterCmd("use wallet {}".format(keyring1))
     assert 'Active wallet set to "{}"'.format(keyring1) in cli.lastCmdOutput
 
-    cli.enterCmd("use identifier {}".format(key1))
-    assert 'Current identifier set to {}'.format(key1) in cli.lastCmdOutput
+    cli.enterCmd("use DID {}".format(key1))
+    assert 'Current DID set to {}'.format(key1) in cli.lastCmdOutput

--- a/plenum/test/cli/test_keyring.py
+++ b/plenum/test/cli/test_keyring.py
@@ -1,8 +1,8 @@
 def createNewKeyring(name, cli):
     oldKeyring = cli.activeWallet
-    cli.enterCmd("new keyring {}".format(name))
-    assert 'Active keyring set to "{}"'.format(name) in cli.lastCmdOutput
-    assert 'New keyring {} created'.format(name) in cli.lastCmdOutput
+    cli.enterCmd("new wallet {}".format(name))
+    assert 'Active wallet set to "{}"'.format(name) in cli.lastCmdOutput
+    assert 'New wallet {} created'.format(name) in cli.lastCmdOutput
     assert not oldKeyring or (
     oldKeyring and oldKeyring.name != cli._activeWallet.name)
     assert cli.activeWallet.name == name
@@ -45,8 +45,8 @@ def testRenameKeyring(cli):
 def testKeyAndKeyRing(cli):
     keyring1 = "testkr1"
     cli.enterCmd("new wallet {}".format(keyring1))
-    assert 'Active keyring set to "{}"'.format(keyring1) in cli.lastCmdOutput
-    assert 'New keyring {} created'.format(keyring1) in cli.lastCmdOutput
+    assert 'Active wallet set to "{}"'.format(keyring1) in cli.lastCmdOutput
+    assert 'New wallet {} created'.format(keyring1) in cli.lastCmdOutput
     cli.enterCmd("list keyrings")
     assert 'testkr1' in cli.lastCmdOutput
 
@@ -61,8 +61,8 @@ def testKeyAndKeyRing(cli):
     assert 'Key created in keyring {}'.format(keyring1) in cli.lastCmdOutput
 
     cli.enterCmd("new wallet {}".format(key1))
-    assert 'Active keyring set to "{}"'.format(key1) in cli.lastCmdOutput
-    assert 'New keyring {} created'.format(key1) in cli.lastCmdOutput
+    assert 'Active wallet set to "{}"'.format(key1) in cli.lastCmdOutput
+    assert 'New wallet {} created'.format(key1) in cli.lastCmdOutput
     cli.enterCmd("list keyrings")
     assert 'testkey1' in cli.lastCmdOutput
 
@@ -74,14 +74,14 @@ def testKeyAndKeyRing(cli):
 
     keyring2 = "testkr2"
     cli.enterCmd("new wallet {}".format(keyring2))
-    assert 'Active keyring set to "{}"'.format(keyring2) in cli.lastCmdOutput
-    assert 'New keyring {} created'.format(keyring2) in cli.lastCmdOutput
+    assert 'Active wallet set to "{}"'.format(keyring2) in cli.lastCmdOutput
+    assert 'New wallet {} created'.format(keyring2) in cli.lastCmdOutput
 
     cli.enterCmd("use identifier {}".format(key1))
     assert 'No such identifier found in current keyring' in cli.lastCmdOutput
 
     cli.enterCmd("use keyring {}".format(keyring1))
-    assert 'Active keyring set to "{}"'.format(keyring1) in cli.lastCmdOutput
+    assert 'Active wallet set to "{}"'.format(keyring1) in cli.lastCmdOutput
 
     cli.enterCmd("use identifier {}".format(key1))
     assert 'Current identifier set to {}'.format(key1) in cli.lastCmdOutput

--- a/plenum/test/cli/test_keyring.py
+++ b/plenum/test/cli/test_keyring.py
@@ -44,7 +44,7 @@ def testRenameKeyring(cli):
 
 def testKeyAndKeyRing(cli):
     keyring1 = "testkr1"
-    cli.enterCmd("new keyring {}".format(keyring1))
+    cli.enterCmd("new wallet {}".format(keyring1))
     assert 'Active keyring set to "{}"'.format(keyring1) in cli.lastCmdOutput
     assert 'New keyring {} created'.format(keyring1) in cli.lastCmdOutput
     cli.enterCmd("list keyrings")
@@ -60,7 +60,7 @@ def testKeyAndKeyRing(cli):
     cli.enterCmd("new key {}".format(key1))
     assert 'Key created in keyring {}'.format(keyring1) in cli.lastCmdOutput
 
-    cli.enterCmd("new keyring {}".format(key1))
+    cli.enterCmd("new wallet {}".format(key1))
     assert 'Active keyring set to "{}"'.format(key1) in cli.lastCmdOutput
     assert 'New keyring {} created'.format(key1) in cli.lastCmdOutput
     cli.enterCmd("list keyrings")
@@ -73,7 +73,7 @@ def testKeyAndKeyRing(cli):
     assert 'No such identifier found in current keyring' in cli.lastCmdOutput
 
     keyring2 = "testkr2"
-    cli.enterCmd("new keyring {}".format(keyring2))
+    cli.enterCmd("new wallet {}".format(keyring2))
     assert 'Active keyring set to "{}"'.format(keyring2) in cli.lastCmdOutput
     assert 'New keyring {} created'.format(keyring2) in cli.lastCmdOutput
 


### PR DESCRIPTION
This is to change the older vocabulary to the newer way of thinking.

'keyring' -> 'wallet'
'link' -> 'connection'
'invitation' -> 'request'
'identifier' -> 'DID'

This change many commands, for example 'new identifier' is now 'new DID'.  The help message and the details within the commands reflect these changes.

These changes break tests in sovrin_client, until the associated updated PR is merged.
