### PR TITLE
INDY-462: fix testPrimaryRecvs3PhaseMessageOutsideWatermarks test

### DIFF
--- a/plenum/test/checkpoints/test_message_outside_watermark1.py
+++ b/plenum/test/checkpoints/test_message_outside_watermark1.py
@@ -4,7 +4,7 @@ from stp_core.common.log import getlogger
 from stp_core.loop.eventually import eventually
 
 from plenum.test import waits
-from plenum.test.delayers import ppDelay, pDelay
+from plenum.test.delayers import ppDelay, pDelay, icDelay
 from plenum.test.helper import sendReqsToNodesAndVerifySuffReplies
 from plenum.test.test_node import getNonPrimaryReplicas, getPrimaryReplica
 from plenum.test.view_change.conftest import perf_chk_patched
@@ -44,6 +44,9 @@ def testPrimaryRecvs3PhaseMessageOutsideWatermarks(perf_chk_patched,
     for r in npr:
         r.node.nodeIbStasher.delay(ppDelay(delay, instId))
         r.node.nodeIbStasher.delay(pDelay(delay, instId))
+        # do not do any view changes since we're dealing with non-master instance and
+        # may have not order all requests if view is changed
+        r.node.nodeIbStasher.delay(icDelay(300))
 
     tm_exec_1_batch = waits.expectedTransactionExecutionTime(len(txnPoolNodeSet))
     batch_count = math.ceil(reqs_to_send / tconf.Max3PCBatchSize)


### PR DESCRIPTION
 - do not do any view changes since we're dealing with non-master instance and may have not order all requests if view is changed