### PR TITLE
Fix 'watermark' test

### DIFF
--- a/plenum/test/checkpoints/test_message_outside_watermark1.py
+++ b/plenum/test/checkpoints/test_message_outside_watermark1.py
@@ -31,7 +31,7 @@ def testPrimaryRecvs3PhaseMessageOutsideWatermarks(perf_chk_patched,
     requests will complete
     """
     tconf = perf_chk_patched
-    delay = 3
+    delay = 5
     instId = 1
     reqs_to_send = 2*reqs_for_logsize + 1
     logger.debug('Will send {} requests'.format(reqs_to_send))


### PR DESCRIPTION
The delay has to be increased because of the performance fix in
the 'logcapture' function (decreased number of re.search). The tests
became faster so delay=3 was not enough.