### PR TITLE
Fix serialization in JsonSerializer

### DIFF
--- a/common/serializers/json_serializer.py
+++ b/common/serializers/json_serializer.py
@@ -38,7 +38,7 @@ except (ImportError, TypeError):
             if isinstance(o, (bytes, bytearray)):
                 return '"{}"'.format(base64.b64encode(o).decode("utf-8"))
             else:
-                return json.JSONEncoder.encode(self, o)
+                return super().encode(o)
 
     JsonEncoder = OrderedJsonEncoder()
 


### PR DESCRIPTION
JsonSerializer uses either json or ujson backends.
It makes configuration but it uses default settings anyway what leads to serialization problems.
This pr fixes it.