### PR TITLE
use latest indy-crypto

### DIFF
--- a/build-scripts/ubuntu-1604/build-3rd-parties.sh
+++ b/build-scripts/ubuntu-1604/build-3rd-parties.sh
@@ -38,40 +38,6 @@ function build_from_pypi {
     rm ${PREREM_TMP}
 }
 
-function build_indy_crypto {
-    PACKAGE_NAME=$1
-
-    if [ -z $2 ]; then
-        PACKAGE_VERSION=""
-    else
-        PACKAGE_VERSION="==$2"
-    fi
-    POSTINST_TMP=postinst-${PACKAGE_NAME}
-    PREREM_TMP=prerm-${PACKAGE_NAME}
-    cp postinst ${POSTINST_TMP}
-    cp prerm ${PREREM_TMP}
-    sed -i 's/{package_name}/'${PACKAGE_NAME}'/' ${POSTINST_TMP}
-    sed -i 's/{package_name}/'${PACKAGE_NAME}'/' ${PREREM_TMP}
-
-    fpm --input-type "python" \
-        --output-type "deb" \
-        --architecture "amd64" \
-        --verbose \
-        --python-bin "/usr/bin/python3" \
-        --exclude "*.pyc" \
-        --exclude "*.pyo" \
-        --maintainer "Hyperledger <hyperledger-indy@lists.hyperledger.org>" \
-        --after-install ${POSTINST_TMP} \
-        --before-remove ${PREREM_TMP} \
-        --package ${OUTPUT_PATH} \
-        --depends libindy-crypto \
-        --name ${PACKAGE_NAME} \
-        ${PACKAGE_NAME}${PACKAGE_VERSION}
-
-    rm ${POSTINST_TMP}
-    rm ${PREREM_TMP}
-}
-
 build_from_pypi ioflo 1.5.4
 build_from_pypi orderedset 2.0
 build_from_pypi base58 0.2.4
@@ -83,4 +49,3 @@ build_from_pypi pyzmq 16.0.2
 build_from_pypi intervaltree 2.1.0
 build_from_pypi portalocker 0.5.7
 build_from_pypi sortedcontainers 1.5.7
-build_indy_crypto python3-indy-crypto 0.1.2

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
                       'ioflo==1.5.4', 'semver', 'base58', 'orderedset',
                       'sortedcontainers==1.5.7', 'psutil', 'pip',
                       'portalocker==0.5.7', 'pyzmq', 'raet',
-                      'psutil', 'intervaltree', 'msgpack-python==0.4.6', 'python3-indy-crypto==0.1.2'],
+                      'psutil', 'intervaltree', 'msgpack-python==0.4.6', 'indy-crypto==0.1.6'],
     extras_require={
         'stats': ['python-firebase'],
         'benchmark': ['pympler']


### PR DESCRIPTION
- building of python-indy-crypto deb is moved to indy-crypto repo;
- increment indy-crypto version
- indy-crypto is renamed (python3 prefix is removed)