### PR TITLE
INDY-580: Improve packaging before supporting CentOS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -203,9 +203,14 @@ def stateTestWindowsNoDocker = {
 
 def buildDebUbuntu = { repoName, releaseVersion, sourcePath ->
     def volumeName = "$name-deb-u1604"
-    sh "docker volume rm -f $volumeName"
+    if (env.BRANCH_NAME != '' && env.BRANCH_NAME != 'master') {
+        volumeName = "${volumeName}.${BRANCH_NAME}"
+    }
+    if (sh(script: "docker volume ls -q | grep -q '^$volumeName\$'", returnStatus: true) == 0) {
+        sh "docker volume rm $volumeName"
+    }
     dir('build-scripts/ubuntu-1604') {
-        sh "./build-$name-docker.sh $sourcePath $releaseVersion"
+        sh "./build-$name-docker.sh \"$sourcePath\" $releaseVersion $volumeName"
         sh "./build-3rd-parties-docker.sh"
     }
     return "$volumeName"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -211,7 +211,7 @@ def buildDebUbuntu = { repoName, releaseVersion, sourcePath ->
     }
     dir('build-scripts/ubuntu-1604') {
         sh "./build-$name-docker.sh \"$sourcePath\" $releaseVersion $volumeName"
-        sh "./build-3rd-parties-docker.sh"
+        sh "./build-3rd-parties-docker.sh $volumeName"
     }
     return "$volumeName"
 }

--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -203,9 +203,14 @@ def stateTestWindowsNoDocker = {
 
 def buildDebUbuntu = { repoName, releaseVersion, sourcePath ->
     def volumeName = "$name-deb-u1604"
-    sh "docker volume rm -f $volumeName"
+    if (env.BRANCH_NAME != '' && env.BRANCH_NAME != 'master') {
+        volumeName = "${volumeName}.${BRANCH_NAME}"
+    }
+    if (sh(script: "docker volume ls -q | grep -q '^$volumeName\$'", returnStatus: true) == 0) {
+        sh "docker volume rm $volumeName"
+    }
     dir('build-scripts/ubuntu-1604') {
-        sh "./build-$name-docker.sh $sourcePath $releaseVersion"
+        sh "./build-$name-docker.sh \"$sourcePath\" $releaseVersion $volumeName"
         sh "./build-3rd-parties-docker.sh"
     }
     return "$volumeName"

--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -211,7 +211,7 @@ def buildDebUbuntu = { repoName, releaseVersion, sourcePath ->
     }
     dir('build-scripts/ubuntu-1604') {
         sh "./build-$name-docker.sh \"$sourcePath\" $releaseVersion $volumeName"
-        sh "./build-3rd-parties-docker.sh"
+        sh "./build-3rd-parties-docker.sh $volumeName"
     }
     return "$volumeName"
 }

--- a/build-scripts/ubuntu-1604/build-3rd-parties-docker.sh
+++ b/build-scripts/ubuntu-1604/build-3rd-parties-docker.sh
@@ -3,22 +3,22 @@
 set -x
 set -e
 
-if [ -z $1 ]; then
+if [ -z "$2" ]; then
     CMD="/root/build-3rd-parties.sh /output"
 else
-    CMD=$1
+    CMD="$2"
 fi
 
 PKG_NAME=indy-plenum
+IMAGE_NAME="${PKG_NAME}-build-u1604"
+OUTPUT_VOLUME_NAME="${1:-"${PKG_NAME}-deb-u1604"}"
 
-docker build -t indy-plenum-build-u1604 -f Dockerfile .
-
-OUTPUT_VOLUME_NAME=${PKG_NAME}-deb-u1604
-docker volume create --name ${OUTPUT_VOLUME_NAME}
+docker build -t "${PKG_NAME}-build-u1604" -f Dockerfile .
+docker volume create --name "${OUTPUT_VOLUME_NAME}"
 
 docker run \
     -i \
     --rm \
-    -v ${OUTPUT_VOLUME_NAME}:/output \
-    indy-plenum-build-u1604 \
+    -v "${OUTPUT_VOLUME_NAME}:/output" \
+    "${IMAGE_NAME}" \
     $CMD

--- a/build-scripts/ubuntu-1604/build-indy-plenum-docker.sh
+++ b/build-scripts/ubuntu-1604/build-indy-plenum-docker.sh
@@ -1,31 +1,31 @@
 #!/bin/bash -xe
 
-PKG_SOURCE_PATH=$1
-VERSION=$2
+PKG_SOURCE_PATH="$1"
+VERSION="$2"
 PKG_NAME=indy-plenum
-IMAGE_NAME=${PKG_NAME}-build-u1604
-OUTPUT_VOLUME_NAME=${PKG_NAME}-deb-u1604
+IMAGE_NAME="${PKG_NAME}-build-u1604"
+OUTPUT_VOLUME_NAME="${3:-"${PKG_NAME}-deb-u1604"}"
 
-if [[ (-z ${PKG_SOURCE_PATH}) || (-z ${VERSION}) ]]; then
-    echo "Usage: $0 <path-to-package-sources> <version>"
+if [[ (-z "${PKG_SOURCE_PATH}") || (-z "${VERSION}") ]]; then
+    echo "Usage: $0 <path-to-package-sources> <version> <volume>"
     exit 1;
 fi
 
-if [ -z $3 ]; then
-    CMD="/root/build-"${PKG_NAME}".sh /input ${VERSION} /output"
+if [ -z "$4" ]; then
+    CMD="/root/build-${PKG_NAME}.sh /input ${VERSION} /output"
 else
-    CMD=$3
+    CMD="$4"
 fi
 
-docker build -t ${IMAGE_NAME} -f Dockerfile .
-docker volume create --name ${OUTPUT_VOLUME_NAME}
+docker build -t "${IMAGE_NAME}" -f Dockerfile .
+docker volume create --name "${OUTPUT_VOLUME_NAME}"
 
 docker run \
     -i \
     --rm \
-    -v ${PKG_SOURCE_PATH}:/input \
-    -v ${OUTPUT_VOLUME_NAME}:/output \
-    -e PKG_NAME=${PKG_NAME} \
-    ${IMAGE_NAME} \
+    -v "${PKG_SOURCE_PATH}:/input" \
+    -v "${OUTPUT_VOLUME_NAME}:/output" \
+    -e PKG_NAME="${PKG_NAME}" \
+    "${IMAGE_NAME}" \
     $CMD
 


### PR DESCRIPTION
- Work around missing "docker volume rm --force" option in older API (< 1.25). So it also works with docker 1.12 provided with CentOS 7 (should not hurt).
- Quote shell variables to support space in paths (always good).
- Support parallel docker builds by adding suffix to volumes in case of multi-branch pipeline (should not change anything for single-branch).

REM: See other PR's for similar improvements in other indy repos (i.e.: for [indy-node](https://github.com/hyperledger/indy-node/pull/381)).