### PR TITLE
[INDY-907] Fix problem with catchup of large ledgers

### DIFF
--- a/plenum/common/batched.py
+++ b/plenum/common/batched.py
@@ -174,7 +174,7 @@ class Batched(MessageProcessor):
             if message_splitter is not None:
                 smaller_parts = message_splitter(part)
                 if smaller_parts is not None:
-                    large_msg_parts.append(part)
+                    large_msg_parts.extend(smaller_parts)
                     continue
 
             large_msg_parts.append(part)

--- a/plenum/common/batched.py
+++ b/plenum/common/batched.py
@@ -9,7 +9,6 @@ from stp_core.common.log import getlogger
 from plenum.common.types import f
 from plenum.common.messages.node_messages import Batch
 from plenum.common.message_processor import MessageProcessor
-from plenum.common.exceptions import InvalidMessageExceedingSizeException
 from stp_core.validators.message_length_validator import MessageLenValidator
 from stp_core.common.config.util import getConfig
 
@@ -51,28 +50,39 @@ class Batched(MessageProcessor):
         for rid in self.remotes.keys():
             self._enqueue(msg, rid, signer)
 
-    def send(self, msg: Any, *
-             rids: Iterable[int], signer: Signer = None) -> None:
+    def send(self,
+             msg: Any, *
+             rids: Iterable[int],
+             signer: Signer = None,
+             message_splitter=None) -> None:
         """
         Enqueue the given message into the outBoxes of the specified remotes
-         or into the outBoxes of all the remotes if rids is None
+        or into the outBoxes of all the remotes if rids is None
 
         :param msg: the message to enqueue
         :param rids: ids of the remotes to whose outBoxes
-         this message must be enqueued
+            this message must be enqueued
+        :param message_splitter: callable that splits msg on
+            two smaller messages
         """
         # Signing (if required) and serializing before enqueueing otherwise
         # each call to `_enqueue` will have to sign it and `transmit` will try
         # to serialize it which is waste of resources
-        serializedPayload, err_msg = self.signSerializeAndCheckLen(msg, signer)
-        if serializedPayload is None:
+        message_parts, err_msg = \
+            self.prepare_for_sending(msg, signer, message_splitter)
+
+        # TODO: returning breaks contract of super class
+        if err_msg is not None:
             return False, err_msg
 
         if rids:
             for r in rids:
-                self._enqueue(serializedPayload, r, signer)
-        else:
-            self._enqueueIntoAllRemotes(serializedPayload, signer)
+                for part in message_parts:
+                    self._enqueue(part, r, signer)
+            return None
+
+        for part in message_parts:
+            self._enqueueIntoAllRemotes(part, signer)
         return True, None
 
     def flushOutBoxes(self) -> None:
@@ -152,16 +162,25 @@ class Batched(MessageProcessor):
                 msg[f.MSGS.nm] = relevantMsgs
         return msg
 
-    def signSerializeAndCheckLen(self, msg, signer=None):
-        msg_bytes = self.sign_and_serialize(msg, signer)
-        err_msg = None
-        try:
-            self.msg_len_val.validate(msg_bytes)
-        except InvalidMessageExceedingSizeException as ex:
-            err_msg = 'Message will be discarded due to {}'.format(ex)
-            logger.warning(err_msg)
-            msg_bytes = None
-        return msg_bytes, err_msg
+    def prepare_for_sending(self, msg, signer,
+                            message_splitter=lambda x: None):
+        large_msg_parts = [msg]
+        fine_msg_parts = []
+        while len(large_msg_parts):
+            part = large_msg_parts.pop()
+            part_bytes = self.sign_and_serialize(part, signer)
+            if self.msg_len_val.is_len_less_than_limit(part_bytes):
+                fine_msg_parts.append(part_bytes)
+                continue
+            smaller_parts = message_splitter(part)
+            if smaller_parts is None:
+                break
+            large_msg_parts.extend(smaller_parts)
+
+        if len(large_msg_parts):
+            return None, "message is too large and cannot be split"
+
+        return fine_msg_parts, None
 
     def sign_and_serialize(self, msg, signer=None):
         payload = self.prepForSending(msg, signer)

--- a/plenum/common/batched.py
+++ b/plenum/common/batched.py
@@ -79,10 +79,9 @@ class Batched(MessageProcessor):
             for r in rids:
                 for part in message_parts:
                     self._enqueue(part, r, signer)
-            return None
-
-        for part in message_parts:
-            self._enqueueIntoAllRemotes(part, signer)
+        else:
+            for part in message_parts:
+                self._enqueueIntoAllRemotes(part, signer)
         return True, None
 
     def flushOutBoxes(self) -> None:

--- a/plenum/common/batched.py
+++ b/plenum/common/batched.py
@@ -169,11 +169,12 @@ class Batched(MessageProcessor):
         while len(large_msg_parts):
             part = large_msg_parts.pop()
             part_bytes = self.sign_and_serialize(part, signer)
-            if self.msg_len_val.is_len_less_than_limit(part_bytes):
+            if self.msg_len_val.is_len_less_than_limit(len(part_bytes)):
                 fine_msg_parts.append(part_bytes)
                 continue
             smaller_parts = message_splitter(part)
             if smaller_parts is None:
+                large_msg_parts.append(part)
                 break
             large_msg_parts.extend(smaller_parts)
 

--- a/plenum/common/batched.py
+++ b/plenum/common/batched.py
@@ -171,11 +171,14 @@ class Batched(MessageProcessor):
             if self.msg_len_val.is_len_less_than_limit(len(part_bytes)):
                 fine_msg_parts.append(part_bytes)
                 continue
-            smaller_parts = message_splitter(part)
-            if smaller_parts is None:
-                large_msg_parts.append(part)
-                break
-            large_msg_parts.extend(smaller_parts)
+            if message_splitter is not None:
+                smaller_parts = message_splitter(part)
+                if smaller_parts is not None:
+                    large_msg_parts.append(part)
+                    continue
+
+            large_msg_parts.append(part)
+            break
 
         if len(large_msg_parts):
             return None, "message is too large and cannot be split"

--- a/plenum/common/ledger_manager.py
+++ b/plenum/common/ledger_manager.py
@@ -1106,18 +1106,21 @@ class LedgerManager(HasActionQueue):
     def _make_split_for_catchup_rep(self, ledger, initial_seq_no):
 
         def _split(message):
+            txns = list(message.txns.items())
             divider = len(message.txns) // 2
-            left = message.txns[:divider]
-            right = message.txns[divider:]
+            left = txns[:divider]
+            left_last_seq_no = left[-1][0]
+            right = txns[divider:]
+            right_last_seq_no = right[-1][0]
             left_cons_proof = self._make_consistency_proof(ledger,
-                                                           left[-1][0],
+                                                           left_last_seq_no,
                                                            initial_seq_no)
             right_cons_proof = self._make_consistency_proof(ledger,
-                                                            right[-1][0],
+                                                            right_last_seq_no,
                                                             initial_seq_no)
             ledger_id = getattr(message, f.LEDGER_ID.nm)
-            left_rep = CatchupRep(ledger_id, left, left_cons_proof)
-            right_rep = CatchupRep(ledger_id, right, right_cons_proof)
+            left_rep = CatchupRep(ledger_id, dict(left), left_cons_proof)
+            right_rep = CatchupRep(ledger_id, dict(right), right_cons_proof)
             return left_rep, right_rep
 
         return _split

--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -2612,7 +2612,12 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
     def transmitToClient(self, msg: Any, remoteName: str):
         self.clientstack.transmitToClient(msg, remoteName)
 
-    def send(self, msg: Any, *rids: Iterable[int], signer: Signer = None):
+    def send(self,
+             msg: Any,
+             *rids: Iterable[int],
+             signer: Signer = None,
+             message_splitter=None):
+
         if rids:
             remoteNames = [self.nodestack.remotes[rid].name for rid in rids]
             recipientsNum = len(remoteNames)
@@ -2624,14 +2629,14 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
 
         logger.debug("{} sending message {} to {} recipients: {}"
                      .format(self, msg, recipientsNum, remoteNames))
-        self.nodestack.send(msg, *rids, signer=signer)
+        self.nodestack.send(msg, *rids, signer=signer, message_splitter=message_splitter)
 
-    def sendToNodes(self, msg: Any, names: Iterable[str] = None):
+    def sendToNodes(self, msg: Any, names: Iterable[str] = None, message_splitter=None):
         # TODO: This method exists in `Client` too, refactor to avoid
         # duplication
         rids = [rid for rid, r in self.nodestack.remotes.items(
         ) if r.name in names] if names else []
-        self.send(msg, *rids)
+        self.send(msg, *rids, message_splitter=message_splitter)
 
     def getReplyFromLedger(self, ledger, request=None, seq_no=None):
         # DoS attack vector, client requesting already processed request id

--- a/plenum/test/cli/test_long_msg_err.py
+++ b/plenum/test/cli/test_long_msg_err.py
@@ -10,4 +10,4 @@ def test_error_if_long_message(
     createClientAndConnect(cli, validNodeNames, "Alice")
 
     cli.enterCmd('client {} send {}'.format("Alice", operation))
-    assert "Message will be discarded due to InvalidMessageExceedingSizeException" in cli.lastCmdOutput
+    assert "message is too large and cannot be split" in cli.lastCmdOutput

--- a/plenum/test/client/test_client.py
+++ b/plenum/test/client/test_client.py
@@ -205,9 +205,13 @@ def testReplyWhenRequestAlreadyExecuted(looper, nodeSet, client1, sent1):
 
     originalRequestResponsesLen = nodeCount * 2
     duplicateRequestRepliesLen = nodeCount  # for a duplicate request we need to
-    serializedPayload, _ = client1.nodestack.signSerializeAndCheckLen(sent1, None)
-    client1.nodestack._enqueueIntoAllRemotes(serializedPayload, None)
 
+    message_parts, err_msg = \
+        client1.nodestack.prepare_for_sending(sent1, None)
+
+    for part in message_parts:
+        client1.nodestack._enqueueIntoAllRemotes(part, None)
+        
     def chk():
         assertLength([response for response in client1.inBox
                       if (response[0].get(f.RESULT.nm) and

--- a/plenum/test/common/test_splitting_large_messages.py
+++ b/plenum/test/common/test_splitting_large_messages.py
@@ -1,0 +1,49 @@
+from plenum.common.batched import Batched
+from plenum.test.testing_utils import FakeSomething
+
+import pytest
+
+
+@pytest.fixture()
+def message_size_limit():
+    return 10
+
+
+@pytest.fixture()
+def batched(message_size_limit):
+    b = Batched(FakeSomething(MSG_LEN_LIMIT=message_size_limit))
+    b.sign_and_serialize = lambda msg, signer: msg
+    return b
+
+
+def test_splitting_large_messages(batched, message_size_limit):
+    """
+    Checks that large message can be split by transport on smaller parts
+    """
+    splitter = lambda x: (x[0:len(x) // 2], x[len(x) // 2:])
+    message = "!" * (message_size_limit * 3)
+    parts, error = batched.prepare_for_sending(message, None, splitter)
+    assert error is None
+    assert len(parts) == 4
+    assert "".join(parts) == message
+
+
+def test_not_splitting_of_small_messages(batched, message_size_limit):
+    """
+    Checks that large message can be split by transport on smaller parts
+    """
+    message = "!" * message_size_limit
+    parts, error = batched.prepare_for_sending(message, None)
+    assert error is None
+    assert parts == [message]
+
+
+def test_fail_if_message_can_be_split(batched, message_size_limit):
+    """
+    Checks that if large message cannot be split by transport on smaller parts
+    error message returned
+    """
+    message = "!" * (message_size_limit + 1)
+    parts, error = batched.prepare_for_sending(message, None)
+    assert error is not None
+    assert parts is None

--- a/plenum/test/node_catchup/test_large_catchup.py
+++ b/plenum/test/node_catchup/test_large_catchup.py
@@ -1,21 +1,42 @@
 import pytest
 
+from plenum.common.messages.node_messages import CatchupRep
 from plenum.test.pool_transactions.helper import \
-    disconnect_node_and_ensure_disconnected
+    disconnect_node_and_ensure_disconnected, \
+    reconnect_node_and_ensure_connected
 from plenum.test.helper import sendReqsToNodesAndVerifySuffReplies
-from plenum.test.node_catchup.helper import waitNodeDataEquality, \
-    checkNodeDataForEquality, ensureClientConnectedToNodesAndPoolLedgerSame
+from plenum.test.node_catchup.helper import waitNodeDataEquality
 
-from plenum.test.pool_transactions.conftest import stewardAndWallet1, \
-    steward1, stewardWallet, clientAndWallet1, client1, wallet1, \
-    client1Connected
-from plenum.test.test_client import genTestClient
+from plenum.test.pool_transactions.conftest import \
+    client1, wallet1, client1Connected
 from plenum.test.test_node import checkNodesConnected
+from stp_core.validators.message_length_validator import MessageLenValidator
 
 
-def test_large_catchup(looper, txnPoolNodeSet, poolTxnClient):
+def fake(node):
+    old = node.nodestack.prepare_for_sending
+
+    def prepare_for_sending(msg, signer, message_splitter=lambda x: None):
+        if isinstance(msg, CatchupRep):
+            node.nodestack.prepare_for_sending = old
+            part_bytes = node.nodestack.sign_and_serialize(msg, signer)
+            new_limit = len(part_bytes) / 2
+            node.nodestack.msg_len_val = MessageLenValidator(new_limit)
+        return old(msg, signer, message_splitter)
+
+    node.nodestack.prepare_for_sending = prepare_for_sending
+
+
+def test_large_catchup(looper,
+                       txnPoolNodeSet,
+                       wallet1,
+                       client1,
+                       client1Connected,
+                       tconf,
+                       allPluginsPath,
+                       tdirWithPoolTxns):
     """
-    Checks that node can catchup large ledger
+    Checks that node can catchup large ledgers
     """
     # Prepare nodes
     lagging_node = txnPoolNodeSet[0]
@@ -24,24 +45,30 @@ def test_large_catchup(looper, txnPoolNodeSet, poolTxnClient):
     looper.run(checkNodesConnected(txnPoolNodeSet))
 
     # Prepare client
-    client, wallet = poolTxnClient
-    looper.add(client)
-    ensureClientConnectedToNodesAndPoolLedgerSame(looper, client, *all_nodes)
+    client, wallet = client1, wallet1
     looper.run(client.ensureConnectedToNodes())
 
     # Check that requests executed well
-    sendReqsToNodesAndVerifySuffReplies(looper, wallet, client, 10)
-    
-    # checkNodeDataForEquality(lagging_node, *txnPoolNodeSet[:-1])
-    #
-    # disconnect_node_and_ensure_disconnected(looper,
-    #                                         txnPoolNodeSet,
-    #                                         lagging_node,
-    #                                         stopNode=False)
-    # looper.removeProdable(lagging_node)
-    #
-    # looper.add(lagging_node)
-    # waitNodeDataEquality(looper, lagging_node, *txnPoolNodeSet[:-1])
-    #
-    # sendReqsToNodesAndVerifySuffReplies(looper, wallet, client, 10)
-    # checkNodeDataForEquality(lagging_node, *txnPoolNodeSet[:-1])
+    sendReqsToNodesAndVerifySuffReplies(looper, wallet, client, numReqs=10)
+
+    # Stop one node
+    waitNodeDataEquality(looper, lagging_node, *rest_nodes)
+    disconnect_node_and_ensure_disconnected(looper,
+                                            rest_nodes,
+                                            lagging_node,
+                                            stopNode=True)
+    looper.removeProdable(lagging_node)
+
+    # Send more requests to active nodes
+    sendReqsToNodesAndVerifySuffReplies(looper, wallet, client, numReqs=100)
+    waitNodeDataEquality(looper, *rest_nodes)
+
+    # Make message size limit smaller to ensure that catchup response is
+    # larger exceeds the limit
+    for node in rest_nodes:
+        fake(node)
+
+    # Restart stopped node and wait for successful catch up
+    looper.add(lagging_node)
+    reconnect_node_and_ensure_connected(looper, all_nodes, lagging_node)
+    waitNodeDataEquality(looper, *all_nodes)

--- a/plenum/test/node_catchup/test_large_catchup.py
+++ b/plenum/test/node_catchup/test_large_catchup.py
@@ -1,0 +1,47 @@
+import pytest
+
+from plenum.test.pool_transactions.helper import \
+    disconnect_node_and_ensure_disconnected
+from plenum.test.helper import sendReqsToNodesAndVerifySuffReplies
+from plenum.test.node_catchup.helper import waitNodeDataEquality, \
+    checkNodeDataForEquality, ensureClientConnectedToNodesAndPoolLedgerSame
+
+from plenum.test.pool_transactions.conftest import stewardAndWallet1, \
+    steward1, stewardWallet, clientAndWallet1, client1, wallet1, \
+    client1Connected
+from plenum.test.test_client import genTestClient
+from plenum.test.test_node import checkNodesConnected
+
+
+def test_large_catchup(looper, txnPoolNodeSet, poolTxnClient):
+    """
+    Checks that node can catchup large ledger
+    """
+    # Prepare nodes
+    lagging_node = txnPoolNodeSet[0]
+    rest_nodes = txnPoolNodeSet[1:]
+    all_nodes = txnPoolNodeSet
+    looper.run(checkNodesConnected(txnPoolNodeSet))
+
+    # Prepare client
+    client, wallet = poolTxnClient
+    looper.add(client)
+    ensureClientConnectedToNodesAndPoolLedgerSame(looper, client, *all_nodes)
+    looper.run(client.ensureConnectedToNodes())
+
+    # Check that requests executed well
+    sendReqsToNodesAndVerifySuffReplies(looper, wallet, client, 10)
+    
+    # checkNodeDataForEquality(lagging_node, *txnPoolNodeSet[:-1])
+    #
+    # disconnect_node_and_ensure_disconnected(looper,
+    #                                         txnPoolNodeSet,
+    #                                         lagging_node,
+    #                                         stopNode=False)
+    # looper.removeProdable(lagging_node)
+    #
+    # looper.add(lagging_node)
+    # waitNodeDataEquality(looper, lagging_node, *txnPoolNodeSet[:-1])
+    #
+    # sendReqsToNodesAndVerifySuffReplies(looper, wallet, client, 10)
+    # checkNodeDataForEquality(lagging_node, *txnPoolNodeSet[:-1])

--- a/plenum/test/replica/test_buffers_cleaning.py
+++ b/plenum/test/replica/test_buffers_cleaning.py
@@ -32,7 +32,7 @@ def test_ordered_cleaning():
 
 def test_primary_names_cleaning():
 
-    node = FakeNode(
+    node = FakeSomething(
         name="fake node",
         ledger_ids=[0],
         viewNo=0,

--- a/plenum/test/replica/test_buffers_cleaning.py
+++ b/plenum/test/replica/test_buffers_cleaning.py
@@ -1,18 +1,12 @@
 from plenum.server.replica import Replica
-
-
-class FakeNode():
-
-    def __init__(self, **kwargs):
-        for name, value in kwargs.items():
-            setattr(self, name, value)
+from plenum.test.testing_utils import FakeSomething
 
 
 def test_ordered_cleaning():
 
     global_view_no = 2
 
-    node = FakeNode(
+    node = FakeSomething(
         name="fake node",
         ledger_ids=[0],
         viewNo=global_view_no,

--- a/plenum/test/testing_utils.py
+++ b/plenum/test/testing_utils.py
@@ -45,3 +45,9 @@ def setupTestLogging():
         style='{')
     console = getConsole()
     console.reinit(verbosity=console.Wordage.concise)
+
+
+class FakeSomething:
+    def __init__(self, **kwargs):
+        for name, value in kwargs.items():
+            setattr(self, name, value)


### PR DESCRIPTION
Problem is caused by message size limitation - catchup response can be to large.
To solve this this pr introduces mechanism for splitting messages on smaller parts