### PR TITLE
[INDY-927] Make client send read only reqeusts to one node

### DIFF
--- a/plenum/client/client.py
+++ b/plenum/client/client.py
@@ -296,7 +296,7 @@ class Client(Motor,
                 logger.debug('Client {} sending request {} to recipients {}'
                              .format(self, request, recipients))
 
-                stat, err_msg = self.send(request, *recipients)
+                stat, err_msg = self.sendToNodes(request, names=recipients)
 
                 if stat:
                     self._expect_replies(request, recipients)
@@ -366,7 +366,8 @@ class Client(Motor,
             if reply:
                 self.txnLog.append(identifier, reqId, reply)
                 return reply
-            elif not self.expectingRepliesFor and numReplies == 1:
+            key = (identifier, reqId)
+            if key not in self.expectingRepliesFor and numReplies == 1:
                 # only one node was asked, but its reply cannot be confirmed,
                 # so ask other nodes
                 self.resendRequests({
@@ -772,7 +773,7 @@ class Client(Motor,
     def sendToNodes(self, msg: Any, names: Iterable[str]):
         rids = [rid for rid, r in self.nodestack.remotes.items()
                 if r.name in names]
-        self.send(msg, *rids)
+        return self.send(msg, *rids)
 
     @staticmethod
     def verifyMerkleProof(*replies: Tuple[Reply]) -> bool:

--- a/plenum/client/client.py
+++ b/plenum/client/client.py
@@ -304,7 +304,7 @@ class Client(Motor,
                 stat, err_msg = self.send(request, *recipients)
 
                 if stat:
-                    self.expectingFor(request, recipients)
+                    self._expect_replies(request, recipients)
                 else:
                     errs.append(err_msg)
                     logger.debug(
@@ -624,9 +624,17 @@ class Client(Motor,
                     tmp.append((req, signer))
             self.reqsPendingConnection.extend(tmp)
 
-    def expectingFor(self, request: Request, nodes: Optional[Set[str]] = None):
-        nodes = nodes or {r.name for r in self.nodestack.remotes.values()
-                          if self.nodestack.isRemoteConnected(r)}
+    def _expect_replies(self, request: Request,
+                        nodes: Optional[Set[str]] = None):
+
+        if nodes is None:
+            connected_nodes = {
+                r.name
+                for r in self.nodestack.remotes.values()
+                if self.nodestack.isRemoteConnected(r)
+            }
+            nodes = connected_nodes
+
         now = time.perf_counter()
         self.expectingAcksFor[request.key] = (nodes, now, 0)
         self.expectingRepliesFor[request.key] = (copy.copy(nodes), now, 0)

--- a/plenum/client/client.py
+++ b/plenum/client/client.py
@@ -349,20 +349,20 @@ class Client(Motor,
                     self.ledgerManager.processCatchupRep(cMsg, frm)
             elif msg[OP_FIELD_NAME] == REQACK:
                 self.reqRepStore.addAck(msg, frm)
-                self.gotExpected(msg, frm)
+                self._got_expected(msg, frm)
             elif msg[OP_FIELD_NAME] == REQNACK:
                 self.reqRepStore.addNack(msg, frm)
-                self.gotExpected(msg, frm)
+                self._got_expected(msg, frm)
             elif msg[OP_FIELD_NAME] == REJECT:
                 self.reqRepStore.addReject(msg, frm)
-                self.gotExpected(msg, frm)
+                self._got_expected(msg, frm)
             elif msg[OP_FIELD_NAME] == REPLY:
                 result = msg[f.RESULT.nm]
                 identifier = msg[f.RESULT.nm][f.IDENTIFIER.nm]
                 reqId = msg[f.RESULT.nm][f.REQ_ID.nm]
                 numReplies = self.reqRepStore.addReply(identifier, reqId, frm,
                                                        result)
-                self.gotExpected(msg, frm)
+                self._got_expected(msg, frm)
                 self.postReplyRecvd(identifier, reqId, frm, result, numReplies)
 
     def postReplyRecvd(self, identifier, reqId, frm, result, numReplies):
@@ -641,7 +641,7 @@ class Client(Motor,
         self.startRepeating(self.retryForExpected,
                             self.config.CLIENT_REQACK_TIMEOUT)
 
-    def gotExpected(self, msg, sender):
+    def _got_expected(self, msg, sender):
 
         def drop(req, register):
             key = (req.get(f.IDENTIFIER.nm), req.get(f.REQ_ID.nm))

--- a/plenum/client/client.py
+++ b/plenum/client/client.py
@@ -664,10 +664,9 @@ class Client(Motor,
             raise RuntimeError("{} cannot retry {}".format(self, msg))
 
         if not self.expectingAcksFor and not self.expectingRepliesFor:
-            # There is no more requests to expect
-            self.stopRetrying()
+            self._stop_expecting()
 
-    def stopRetrying(self):
+    def _stop_expecting(self):
         self.stopRepeating(self.retryForExpected, strict=False)
 
     def _filterExpected(self, now, queue, retryTimeout, maxRetry):

--- a/plenum/client/client.py
+++ b/plenum/client/client.py
@@ -286,16 +286,16 @@ class Client(Motor,
         errs = []
 
         for request in reqs:
+            is_read_only = request.txn_type in self._read_only_requests
             if (self.mode == Mode.discovered and self.hasSufficientConnections) or \
-               (self.hasAnyConnections and
-               (request.txn_type in self._read_only_requests or request.isForced())):
+               (self.hasAnyConnections and (is_read_only or request.isForced())):
 
                 recipients = \
                     {r.name
                      for r in self.nodestack.remotes.values()
                      if self.nodestack.isRemoteConnected(r)}
 
-                if request.txn_type in self._read_only_requests and len(recipients) > 1:
+                if is_read_only and len(recipients) > 1:
                     recipients = random.sample(list(recipients), 1)
 
                 logger.debug('Client {} sending request {} to recipients {}'

--- a/plenum/client/client.py
+++ b/plenum/client/client.py
@@ -6,6 +6,7 @@ and receives result of the request execution from nodes.
 
 import copy
 import os
+import random
 import time
 from collections import deque, OrderedDict
 from functools import partial
@@ -293,6 +294,9 @@ class Client(Motor,
                     {r.name
                      for r in self.nodestack.remotes.values()
                      if self.nodestack.isRemoteConnected(r)}
+
+                if request.txn_type in self._read_only_requests and len(recipients) > 1:
+                    recipients = random.sample(list(recipients), 1)
 
                 logger.debug('Client {} sending request {} to recipients {}'
                              .format(self, request, recipients))

--- a/plenum/client/client.py
+++ b/plenum/client/client.py
@@ -653,13 +653,13 @@ class Client(Motor,
                     register.pop(key)
 
         if msg[OP_FIELD_NAME] == REQACK:
-            drop(self.expectingAcksFor, msg)
+            drop(msg, self.expectingAcksFor)
         elif msg[OP_FIELD_NAME] == REPLY:
-            drop(self.expectingAcksFor, msg[f.RESULT.nm])
-            drop(self.expectingRepliesFor, msg[f.RESULT.nm])
+            drop(msg[f.RESULT.nm], self.expectingAcksFor)
+            drop(msg[f.RESULT.nm], self.expectingRepliesFor)
         elif msg[OP_FIELD_NAME] in (REQNACK, REJECT):
-            drop(self.expectingAcksFor, msg)
-            drop(self.expectingRepliesFor, msg)
+            drop(msg, self.expectingAcksFor)
+            drop(msg, self.expectingRepliesFor)
         else:
             raise RuntimeError("{} cannot retry {}".format(self, msg))
 

--- a/plenum/client/client.py
+++ b/plenum/client/client.py
@@ -762,8 +762,6 @@ class Client(Motor,
                 elif force_expect:
                     queue[key] = (nodes, now, 1)
 
-
-
     def sendLedgerStatus(self, nodeName: str):
         ledgerStatus = LedgerStatus(
             POOL_LEDGER_ID,

--- a/plenum/client/client.py
+++ b/plenum/client/client.py
@@ -599,21 +599,6 @@ class Client(Motor,
     def hasAnyConnections(self):
         return len(self.nodestack.conns) > 0
 
-    def hasMadeRequest(self, identifier, reqId: int):
-        return self.reqRepStore.hasRequest(identifier, reqId)
-
-    def isRequestSuccessful(self, identifier, reqId):
-        acks = self.reqRepStore.getAcks(identifier, reqId)
-        nacks = self.reqRepStore.getNacks(identifier, reqId)
-        f = getMaxFailures(len(self.nodeReg))
-        if len(acks) > f:
-            return True, "Done"
-        elif len(nacks) > f:
-            # TODO: What if the the nacks were different from each node?
-            return False, list(nacks.values())[0]
-        else:
-            return None
-
     def pendReqsTillConnection(self, request, signer=None):
         """
         Enqueue requests that need to be submitted until the client has

--- a/plenum/common/util.py
+++ b/plenum/common/util.py
@@ -72,7 +72,6 @@ def randomString(size: int = 20) -> str:
 def random_from_alphabet(size, alphabet):
     """
     Takes *size* random elements from provided alphabet
-    
     :param size:
     :param alphabet:
     """

--- a/plenum/common/util.py
+++ b/plenum/common/util.py
@@ -57,6 +57,7 @@ def randomString(size: int = 20) -> str:
         assert (size > 0), "Expected random string size cannot be less than 1"
         # Approach 1
         rv = randombytes(size // 2).hex()
+
         return rv if size % 2 == 0 else rv + hex(randombytes_uniform(15))[-1]
 
         # Approach 2 this is faster than Approach 1, but lovesh had a doubt
@@ -66,6 +67,17 @@ def randomString(size: int = 20) -> str:
         # return rstr[:size]
 
     return randomStr(size)
+
+
+def random_from_alphabet(size, alphabet):
+    """
+    Takes *size* random elements from provided alphabet
+    
+    :param size:
+    :param alphabet:
+    """
+    import random
+    return list(random.choice(alphabet) for _ in range(size))
 
 
 def randomSeed(size=32):

--- a/plenum/test/bls/helper.py
+++ b/plenum/test/bls/helper.py
@@ -5,13 +5,15 @@ from common.serializers.serialization import state_roots_serializer
 from plenum.common.constants import DOMAIN_LEDGER_ID, ALIAS, BLS_KEY
 from plenum.common.keygen_utils import init_bls_keys
 from plenum.common.messages.node_messages import Commit, Prepare, PrePrepare
-from plenum.common.util import get_utc_epoch, randomString
+from plenum.common.util import get_utc_epoch, randomString, random_from_alphabet
 from plenum.test.helper import sendRandomRequests, waitForSufficientRepliesForRequests
 from plenum.test.node_catchup.helper import waitNodeDataEquality, ensureClientConnectedToNodesAndPoolLedgerSame
 from plenum.test.pool_transactions.helper import updateNodeData, buildPoolClientAndWallet, new_client
 
+
 def generate_state_root():
     return base58.b58encode(os.urandom(32))
+
 
 def check_bls_multi_sig_after_send(looper, txnPoolNodeSet,
                                    client, wallet,
@@ -154,7 +156,12 @@ def change_bls_key(looper, txnPoolNodeSet, tdirWithPoolTxns,
                    steward_client, steward_wallet,
                    add_wrong=False):
     new_blspk = init_bls_keys(tdirWithPoolTxns, node.name)
-    key_in_txn = new_blspk if not add_wrong else randomString(32)
+
+    key_in_txn = \
+        new_blspk \
+        if not add_wrong \
+        else ''.join(random_from_alphabet(32, base58.alphabet))
+
     node_data = {
         ALIAS: node.name,
         BLS_KEY: key_in_txn

--- a/plenum/test/bls/test_no_state_proof.py
+++ b/plenum/test/bls/test_no_state_proof.py
@@ -15,7 +15,7 @@ def test_make_proof_bls_disabled(looper, txnPoolNodeSet,
 
     req = reqs[0]
     for node in txnPoolNodeSet:
-        key = node.reqHandler.prepare_buy_key(req.identifier, req.reqId)
+        key = node.reqHandler.prepare_buy_key(req.identifier)
         proof = node.reqHandler.make_proof(key)
         assert not proof
 
@@ -27,7 +27,7 @@ def test_make_result_bls_disabled(looper, txnPoolNodeSet,
 
     req = reqs[0]
     for node in txnPoolNodeSet:
-        key = node.reqHandler.prepare_buy_key(req.identifier, req.reqId)
+        key = node.reqHandler.prepare_buy_key(req.identifier)
         proof = node.reqHandler.make_proof(key)
         result = node.reqHandler.make_result(req,
                                              {TXN_TYPE: "buy"},

--- a/plenum/test/bls/test_state_proof.py
+++ b/plenum/test/bls/test_state_proof.py
@@ -17,7 +17,7 @@ nodes_wth_bls = 4
 
 def check_result(txnPoolNodeSet, req, client, should_have_proof):
     for node in txnPoolNodeSet:
-        key = node.reqHandler.prepare_buy_key(req.identifier, req.reqId)
+        key = node.reqHandler.prepare_buy_key(req.identifier)
         proof = node.reqHandler.make_proof(key)
 
         txn_time = get_utc_epoch()
@@ -47,7 +47,7 @@ def test_make_proof_bls_enabled(looper, txnPoolNodeSet,
 
     req = reqs[0]
     for node in txnPoolNodeSet:
-        key = node.reqHandler.prepare_buy_key(req.identifier, req.reqId)
+        key = node.reqHandler.prepare_buy_key(req.identifier)
         proof = node.reqHandler.make_proof(key)
 
         assert proof

--- a/plenum/test/client/test_client_resends_not_confirmed_request.py
+++ b/plenum/test/client/test_client_resends_not_confirmed_request.py
@@ -1,12 +1,8 @@
 import random
 
-from plenum.common.constants import REPLY, OP_FIELD_NAME
-from plenum.common.types import f
-from plenum.test.spy_helpers import getAllArgs
 from stp_core.common.log import getlogger
-from stp_core.loop.eventually import eventually
 from plenum.test.client.conftest import passThroughReqAcked1
-from plenum.test.helper import stopNodes, send_signed_requests, \
+from plenum.test.helper import send_signed_requests, \
     waitForSufficientRepliesForRequests
 from plenum.test.malicious_behaviors_client import \
     genDoesntSendRequestToSomeNodes
@@ -16,27 +12,7 @@ logger = getlogger()
 nodeCount = 4
 clientFault = genDoesntSendRequestToSomeNodes("AlphaC")
 reqAcked1 = passThroughReqAcked1
-
-
-def fake_send(client):
-    old_sendToNodes = client.sendToNodes
-
-    def sendToNodes(msg, names):
-        client.sendToNodes = old_sendToNodes
-        assert len(names) == 1
-        name = names[0]
-        old_got_expected = client._got_expected
-
-        def _got_expected(msg, sender):
-            if sender == name and msg[OP_FIELD_NAME] == REPLY:
-                client._got_expected = old_got_expected
-                msg[f.RESULT.nm].pop("state_proof", None)
-            return old_got_expected(msg, sender)
-
-        client._got_expected = _got_expected
-        return old_sendToNodes(msg, names)
-
-    client.sendToNodes = sendToNodes
+nodes_with_bls = 0
 
 
 def test_client_resends_not_confirmed_request(looper,
@@ -61,7 +37,6 @@ def test_client_resends_not_confirmed_request(looper,
     requests = sign_and_send(buy)
     waitForSufficientRepliesForRequests(looper, client, requests=requests)
 
-    fake_send(client)
     buy = {'type': 'get_buy'}
     client._read_only_requests.add('get_buy')
     requests = sign_and_send(buy)

--- a/plenum/test/client/test_client_resends_not_confirmed_request.py
+++ b/plenum/test/client/test_client_resends_not_confirmed_request.py
@@ -1,0 +1,75 @@
+import random
+
+from plenum.common.constants import REPLY, OP_FIELD_NAME
+from plenum.common.types import f
+from plenum.test.spy_helpers import getAllArgs
+from stp_core.common.log import getlogger
+from stp_core.loop.eventually import eventually
+from plenum.test.client.conftest import passThroughReqAcked1
+from plenum.test.helper import stopNodes, send_signed_requests, \
+    waitForSufficientRepliesForRequests
+from plenum.test.malicious_behaviors_client import \
+    genDoesntSendRequestToSomeNodes
+
+logger = getlogger()
+
+nodeCount = 4
+clientFault = genDoesntSendRequestToSomeNodes("AlphaC")
+reqAcked1 = passThroughReqAcked1
+
+
+def fake_send(client):
+    old_sendToNodes = client.sendToNodes
+
+    def sendToNodes(msg, names):
+        client.sendToNodes = old_sendToNodes
+        assert len(names) == 1
+        name = names[0]
+        old_got_expected = client._got_expected
+
+        def _got_expected(msg, sender):
+            if sender == name and msg[OP_FIELD_NAME] == REPLY:
+                client._got_expected = old_got_expected
+                msg[f.RESULT.nm].pop("state_proof", None)
+            return old_got_expected(msg, sender)
+
+        client._got_expected = _got_expected
+        return old_sendToNodes(msg, names)
+
+    client.sendToNodes = sendToNodes
+
+
+def test_client_resends_not_confirmed_request(looper,
+                                              client1,
+                                              wallet1,
+                                              nodeSet):
+    """
+    Check that client resends request to all nodes if it was previously sent
+    to one node but reply cannot be verified
+    """
+    client = client1
+    wallet = wallet1
+
+    initial_submit_count = client.spylog.count(client.submitReqs)
+    initial_resent_count = client.spylog.count(client.resendRequests)
+
+    def sign_and_send(op):
+        signed = wallet.signOp(op)
+        return send_signed_requests(client, [signed])
+
+    buy = {'type': 'buy', 'amount': random.randint(10, 100)}
+    requests = sign_and_send(buy)
+    waitForSufficientRepliesForRequests(looper, client, requests=requests)
+
+    fake_send(client)
+    buy = {'type': 'get_buy'}
+    client._read_only_requests.add('get_buy')
+    requests = sign_and_send(buy)
+    waitForSufficientRepliesForRequests(looper, client, requests=requests)
+
+    # submitReqs should be called twice: first for but and then got get_buy
+    assert initial_submit_count + 2 == \
+           client.spylog.count(client.submitReqs)
+
+    assert initial_resent_count + 1 == \
+           client.spylog.count(client.resendRequests)

--- a/plenum/test/client/test_client_sends_get_request_to_one_node.py
+++ b/plenum/test/client/test_client_sends_get_request_to_one_node.py
@@ -15,6 +15,38 @@ clientFault = genDoesntSendRequestToSomeNodes("AlphaC")
 reqAcked1 = passThroughReqAcked1
 
 
+def test_client_sends_get_request_to_one_node(looper,
+                                              client1,
+                                              wallet1,
+                                              nodeSet):
+    """
+    Check that client sends read only request to one node only
+    """
+    client = client1
+    wallet = wallet1
+
+    def sign_and_send(op):
+        signed = wallet.signOp(op)
+        send_signed_requests(client, [signed])
+
+    logger.info("Send set request")
+    buy = {'type': 'buy', 'amount': random.randint(10, 100)}
+    sign_and_send(buy)
+
+    send_args = getAllArgs(client, client.send)
+    rids = send_args[0]['rids']
+    assert len(rids) > 1
+
+    logger.info("Send get request")
+    get_buy = {'type': 'get_buy'}
+    client._read_only_requests.add('get_buy')
+    sign_and_send(get_buy)
+
+    send_args = getAllArgs(client, client.send)
+    rids = send_args[0]['rids']
+    assert len(rids) == 1
+
+
 def test_client_can_send_get_request_to_one_node(looper,
                                                  client1,
                                                  wallet1,
@@ -56,35 +88,3 @@ def test_client_can_send_get_request_to_one_node(looper,
     sign_and_send(get_buy)
     assert initial_submit_count + 2 == client.spylog.count(client.submitReqs)
     assert initial_send_count + 1 == client.spylog.count(client.send)
-
-
-def test_client_sends_get_request_to_one_node(looper,
-                                              client1,
-                                              wallet1,
-                                              nodeSet):
-    """
-    Check that client sends read only request to one node only
-    """
-    client = client1
-    wallet = wallet1
-
-    def sign_and_send(op):
-        signed = wallet.signOp(op)
-        send_signed_requests(client, [signed])
-
-    logger.info("Send set request")
-    buy = {'type': 'buy', 'amount': random.randint(10, 100)}
-    sign_and_send(buy)
-
-    send_args = getAllArgs(client, client.send)
-    rids = send_args[0]['rids']
-    assert len(rids) > 1
-
-    logger.info("Send get request")
-    get_buy = {'type': 'get_buy'}
-    client._read_only_requests.add('get_buy')
-    sign_and_send(get_buy)
-
-    send_args = getAllArgs(client, client.send)
-    rids = send_args[0]['rids']
-    assert len(rids) == 1

--- a/plenum/test/client/test_client_sends_get_request_to_one_node.py
+++ b/plenum/test/client/test_client_sends_get_request_to_one_node.py
@@ -1,15 +1,12 @@
 import random
 
+from plenum.test.spy_helpers import getAllArgs
 from stp_core.common.log import getlogger
 from stp_core.loop.eventually import eventually
-
 from plenum.test.client.conftest import passThroughReqAcked1
-
-from plenum.test.helper import sendReqsToNodesAndVerifySuffReplies, stopNodes, waitForSufficientRepliesForRequests, \
-    send_signed_requests
+from plenum.test.helper import stopNodes, send_signed_requests
 from plenum.test.malicious_behaviors_client import \
     genDoesntSendRequestToSomeNodes
-from plenum.test.node_catchup.helper import waitNodeDataEquality
 
 logger = getlogger()
 
@@ -17,12 +14,13 @@ nodeCount = 4
 clientFault = genDoesntSendRequestToSomeNodes("AlphaC")
 reqAcked1 = passThroughReqAcked1
 
-def test_client_sends_get_request_to_one_node(looper,
-                                              client1,
-                                              wallet1,
-                                              nodeSet):
+
+def test_client_can_send_get_request_to_one_node(looper,
+                                                 client1,
+                                                 wallet1,
+                                                 nodeSet):
     """
-    Check that read only equest can be sent
+    Check that read only request can be sent
     without having connection to all nodes
     """
     client = client1
@@ -58,3 +56,35 @@ def test_client_sends_get_request_to_one_node(looper,
     sign_and_send(get_buy)
     assert initial_submit_count + 2 == client.spylog.count(client.submitReqs)
     assert initial_send_count + 1 == client.spylog.count(client.send)
+
+
+def test_client_sends_get_request_to_one_node(looper,
+                                              client1,
+                                              wallet1,
+                                              nodeSet):
+    """
+    Check that client sends read only request to one node only
+    """
+    client = client1
+    wallet = wallet1
+
+    def sign_and_send(op):
+        signed = wallet.signOp(op)
+        send_signed_requests(client, [signed])
+
+    logger.info("Send set request")
+    buy = {'type': 'buy', 'amount': random.randint(10, 100)}
+    sign_and_send(buy)
+
+    send_args = getAllArgs(client, client.send)
+    rids = send_args[0]['rids']
+    assert len(rids) > 1
+
+    logger.info("Send get request")
+    get_buy = {'type': 'get_buy'}
+    client._read_only_requests.add('get_buy')
+    sign_and_send(get_buy)
+
+    send_args = getAllArgs(client, client.send)
+    rids = send_args[0]['rids']
+    assert len(rids) == 1

--- a/plenum/test/test_node.py
+++ b/plenum/test/test_node.py
@@ -271,7 +271,7 @@ class TestNodeCore(StackedTester):
 
 node_spyables = [Node.handleOneNodeMsg,
                  Node.handleInvalidClientMsg,
-                 Node.processRequest,
+                 Node.processRequest.__name__,
                  Node.processOrdered,
                  Node.postToClientInBox,
                  Node.postToNodeInBox,

--- a/plenum/test/testable.py
+++ b/plenum/test/testable.py
@@ -87,6 +87,7 @@ def spy(func, is_init, should_spy, spy_log=None):
         finally:
             bound = sig.bind(self, *args, **kwargs)
             params = dict(bound.arguments)
+            params.pop('self', None)
             used_log = self.spylog if hasattr(self, 'spylog') else spy_log
             used_log.append(Entry(start,
                                   time.perf_counter(),

--- a/plenum/test/testable.py
+++ b/plenum/test/testable.py
@@ -59,10 +59,6 @@ class SpyLog(list):
 
 def spy(func, is_init, should_spy, spy_log=None):
     sig = inspect.signature(func)
-    paramNames = [k for k in sig.parameters]
-    # TODO Find a better way
-    if paramNames and paramNames[0] == "self":
-        paramNames = paramNames[1:]
 
     # sets up spylog, but doesn't spy on init
     def init_only(self, *args, **kwargs):
@@ -89,19 +85,9 @@ def spy(func, is_init, should_spy, spy_log=None):
             r = ex
             raise
         finally:
-            params = {}
-            if kwargs:
-                for k, v in kwargs.items():
-                    params[k] = v
-            if args:
-                for i, nm in enumerate(paramNames[:len(args)]):
-                    params[nm] = args[i]
-
-            used_log = spy_log
-
-            if hasattr(self, 'spylog'):
-                used_log = self.spylog
-
+            bound = sig.bind(self, *args, **kwargs)
+            params = dict(bound.arguments)
+            used_log = self.spylog if hasattr(self, 'spylog') else spy_log
             used_log.append(Entry(start,
                                   time.perf_counter(),
                                   func.__name__,


### PR DESCRIPTION
Before this PR client was able to send request to one node if there is no sufficient connections.
This PR makes it send to one node always.