### PR TITLE
Fix infinit InstanceChange when no new requests

### DIFF
--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -388,6 +388,8 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         self.total_read_request_number = 0
         self._info_tool = self._info_tool_class(self)
 
+        self._last_performance_check_data = {}
+
     def create_replicas(self) -> Replicas:
         return Replicas(self, self.monitor)
 
@@ -2052,6 +2054,14 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         # nodes
         if not self.isParticipating:
             return
+
+        last_num_ordered = self._last_performance_check_data.get('num_ordered')
+        num_ordered = sum(num for num, _ in self.monitor.numOrderedRequests)
+        nothing_changed = num_ordered == last_num_ordered
+        if nothing_changed:
+            return
+
+        self._last_performance_check_data['num_ordered'] = num_ordered
 
         if self.instances.masterId is not None:
             self.sendNodeRequestSpike()

--- a/plenum/server/propagator.py
+++ b/plenum/server/propagator.py
@@ -241,12 +241,12 @@ class Propagator:
         :param request: the REQUEST to propagate
         """
         key = request.key
-        logger.debug('{} forwarding request {} to {} replicas'.format(
-            self, key, self.replicas.sum_inbox_len))
-
+        num_replicas = self.replicas.num_replicas
+        logger.debug('{} forwarding request {} to {} replicas'
+                     .format(self, key, num_replicas))
         self.replicas.pass_message(ReqKey(*key))
         self.monitor.requestUnOrdered(*key)
-        self.requests.mark_as_forwarded(request, self.replicas.num_replicas)
+        self.requests.mark_as_forwarded(request, num_replicas)
 
     # noinspection PyUnresolvedReferences
     def recordAndPropagate(self, request: Request, clientName):

--- a/plenum/test/monitoring/test_no_check_if_no_new_requests.py
+++ b/plenum/test/monitoring/test_no_check_if_no_new_requests.py
@@ -1,0 +1,35 @@
+from stp_core.loop.looper import Looper
+from plenum.test.test_node import TestNodeSet
+from plenum.test.helper import sendReqsToNodesAndVerifySuffReplies
+
+
+def test_not_check_if_no_new_requests(looper: Looper,
+                                      nodeSet: TestNodeSet,
+                                      wallet1, client1):
+    """
+    Checks that node does not do performance check if there were no new
+    requests since previous check
+    """
+    
+    # Ensure that nodes participating, because otherwise they do not do check
+    for node in list(nodeSet):
+        assert node.isParticipating
+
+    # Check that first performance checks passes, but further do not
+    for node in list(nodeSet):
+        assert node.checkPerformance()
+        assert not node.checkPerformance()
+        assert not node.checkPerformance()
+        assert not node.checkPerformance()
+
+    # Send new request and check that after it nodes can do
+    # performance check again
+    num_requests = 1
+    sendReqsToNodesAndVerifySuffReplies(looper,
+                                        wallet1,
+                                        client1,
+                                        num_requests,
+                                        nodeSet.f)
+
+    for node in list(nodeSet):
+        assert node.checkPerformance()


### PR DESCRIPTION
Do not do performance check if there is no new requests since last check. 
It prevents infinit sending of InstanceChange messages if other nodes do not reply to it.