### PR TITLE
INDY-893: fix recovering tree from txn log

### DIFF
--- a/ledger/compact_merkle_tree.py
+++ b/ledger/compact_merkle_tree.py
@@ -6,8 +6,8 @@ import ledger.merkle_tree as merkle_tree
 from ledger.hash_stores.hash_store import HashStore
 from ledger.hash_stores.memory_hash_store import MemoryHashStore
 from ledger.tree_hasher import TreeHasher
-from ledger.util import count_bits_set, lowest_bit_set
 from ledger.util import ConsistencyVerificationFailed
+from ledger.util import count_bits_set, lowest_bit_set
 
 
 class CompactMerkleTree(merkle_tree.MerkleTree):
@@ -249,7 +249,7 @@ class CompactMerkleTree(merkle_tree.MerkleTree):
                 return self._path(m - k, start_n + k, end_n) + [
                     (start_n, start_n + k)]
 
-    def get_tree_head(self, seq: int=None):
+    def get_tree_head(self, seq: int = None):
         if seq is None:
             seq = self.tree_size
         if seq > self.tree_size:
@@ -288,3 +288,8 @@ class CompactMerkleTree(merkle_tree.MerkleTree):
         if self.get_expected_node_count(self.leafCount) != self.nodeCount:
             raise ConsistencyVerificationFailed()
         return True
+
+    def reset(self):
+        self.hashStore.reset()
+        self._update(tree_size=0,
+                     hashes=())

--- a/ledger/ledger.py
+++ b/ledger/ledger.py
@@ -83,7 +83,8 @@ class Ledger(ImmutableStore):
 
     def recoverTreeFromTxnLog(self):
         # TODO: in this and some other lines specific fields of
-        self.tree.hashStore.reset()
+        self.tree.reset()
+        self.seqNo = 0
         for key, entry in self._transactionLog.iterator():
             if self.txn_serializer != self.hash_serializer:
                 entry = self.serialize_for_tree(

--- a/ledger/merkle_tree.py
+++ b/ledger/merkle_tree.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod, ABCMeta
-from typing import List, Tuple
+from typing import Tuple
 
 from ledger.hash_stores.hash_store import HashStore
 
@@ -79,5 +79,11 @@ class MerkleTree(metaclass=ABCMeta):
     @property
     @abstractmethod
     def hashStore(self) -> HashStore:
+        """
+        """
+
+    @property
+    @abstractmethod
+    def reset(self):
         """
         """

--- a/ledger/test/conftest.py
+++ b/ledger/test/conftest.py
@@ -92,6 +92,7 @@ def create_ledger_callable(request):
     elif request.param == 'LeveldbStorage':
         return create_ledger_leveldb_file_storage
 
+
 @pytest.yield_fixture(scope="function", params=['TextFileStorage', 'ChunkedFileStorage', 'LeveldbStorage'])
 def ledger_no_genesis(request, tempdir, txn_serializer, hash_serializer):
     ledger = create_ledger(request, txn_serializer, hash_serializer, tempdir)

--- a/ledger/test/conftest.py
+++ b/ledger/test/conftest.py
@@ -6,8 +6,8 @@ from common.serializers.json_serializer import JsonSerializer
 from common.serializers.msgpack_serializer import MsgPackSerializer
 from common.serializers.signing_serializer import SigningSerializer
 from ledger.genesis_txn.genesis_txn_file_util import create_genesis_txn_init_ledger
-from ledger.genesis_txn.genesis_txn_initiator_from_file import GenesisTxnInitiatorFromFile
-from ledger.test.helper import create_ledger
+from ledger.test.helper import create_ledger, create_ledger_text_file_storage, create_ledger_chunked_file_storage, \
+    create_ledger_leveldb_file_storage
 
 
 @pytest.fixture(scope='module')
@@ -82,6 +82,15 @@ def ledger(request, genesis_txn_file, tempdir, txn_serializer, hash_serializer):
     yield ledger
     ledger.stop()
 
+
+@pytest.yield_fixture(scope="function", params=['TextFileStorage', 'ChunkedFileStorage', 'LeveldbStorage'])
+def create_ledger_callable(request):
+    if request.param == 'TextFileStorage':
+        return create_ledger_text_file_storage
+    elif request.param == 'ChunkedFileStorage':
+        return create_ledger_chunked_file_storage
+    elif request.param == 'LeveldbStorage':
+        return create_ledger_leveldb_file_storage
 
 @pytest.yield_fixture(scope="function", params=['TextFileStorage', 'ChunkedFileStorage', 'LeveldbStorage'])
 def ledger_no_genesis(request, tempdir, txn_serializer, hash_serializer):

--- a/ledger/test/test_ledger.py
+++ b/ledger/test/test_ledger.py
@@ -9,11 +9,9 @@ from common.serializers.msgpack_serializer import MsgPackSerializer
 from ledger.compact_merkle_tree import CompactMerkleTree
 from ledger.test.conftest import orderedFields
 from ledger.test.helper import NoTransactionRecoveryLedger, \
-    check_ledger_generator, create_ledger_text_file_storage, create_ledger_chunked_file_storage, \
-    create_ledger_leveldb_file_storage, create_default_ledger, random_txn
+    check_ledger_generator, create_ledger_text_file_storage, create_default_ledger, random_txn
 from ledger.test.test_file_hash_store import generateHashes
 from ledger.util import ConsistencyVerificationFailed, F
-from storage.text_file_store import TextFileStore
 
 
 def b64e(s):
@@ -89,25 +87,11 @@ creation of Signed Tree Heads? I think I don't really understand what STHs are)
 """
 
 
-def test_recover_merkle_tree_from_txn_log_text_file(tempdir, txn_serializer, hash_serializer, genesis_txn_file):
-    check_recover_merkle_tree_from_txn_log(create_ledger_text_file_storage,
-                                           tempdir, txn_serializer, hash_serializer, genesis_txn_file)
-
-
-def test_recover_merkle_tree_from_txn_log_chunked_file(tempdir, txn_serializer, hash_serializer, genesis_txn_file):
-    check_recover_merkle_tree_from_txn_log(create_ledger_chunked_file_storage,
-                                           tempdir, txn_serializer, hash_serializer, genesis_txn_file)
-
-
-def test_recover_merkle_tree_from_txn_log_leveldb_file(tempdir, txn_serializer, hash_serializer, genesis_txn_file):
-    check_recover_merkle_tree_from_txn_log(create_ledger_leveldb_file_storage,
-                                           tempdir, txn_serializer, hash_serializer, genesis_txn_file)
-
-
-def check_recover_merkle_tree_from_txn_log(create_ledger_func, tempdir, txn_serializer, hash_serializer, genesis_txn_file):
-    ledger = create_ledger_func(
+def test_recover_merkle_tree_from_txn_log(create_ledger_callable, tempdir,
+                                          txn_serializer, hash_serializer, genesis_txn_file):
+    ledger = create_ledger_callable(
         txn_serializer, hash_serializer, tempdir, genesis_txn_file)
-    for d in range(100):
+    for d in range(5):
         ledger.add(random_txn(d))
     # delete hash store, so that the only option for recovering is txn log
     ledger.tree.hashStore.reset()
@@ -119,8 +103,8 @@ def check_recover_merkle_tree_from_txn_log(create_ledger_func, tempdir, txn_seri
     root_hash_before = ledger.root_hash
     hashes_before = ledger.tree.hashes
 
-    restartedLedger = create_ledger_func(
-        txn_serializer, hash_serializer, tempdir, genesis_txn_file)
+    restartedLedger = create_ledger_callable(txn_serializer,
+                                             hash_serializer, tempdir, genesis_txn_file)
 
     assert size_before == restartedLedger.size
     assert root_hash_before == restartedLedger.root_hash
@@ -129,18 +113,23 @@ def check_recover_merkle_tree_from_txn_log(create_ledger_func, tempdir, txn_seri
     assert tree_size_before == restartedLedger.tree.tree_size
 
 
-def test_recover_merkle_tree_from_hash_store(tempdir):
-    ledger = create_default_ledger(tempdir)
-    for d in range(100):
+def test_recover_merkle_tree_from_hash_store(create_ledger_callable, tempdir,
+                                             txn_serializer, hash_serializer, genesis_txn_file):
+    ledger = create_ledger_callable(
+        txn_serializer, hash_serializer, tempdir, genesis_txn_file)
+    for d in range(5):
         ledger.add(random_txn(d))
     ledger.stop()
+
     size_before = ledger.size
     tree_root_hash_before = ledger.tree.root_hash
     tree_size_before = ledger.tree.tree_size
     root_hash_before = ledger.root_hash
     hashes_before = ledger.tree.hashes
 
-    restartedLedger = create_default_ledger(tempdir)
+    restartedLedger = create_ledger_callable(txn_serializer,
+                                             hash_serializer, tempdir, genesis_txn_file)
+
     assert size_before == restartedLedger.size
     assert root_hash_before == restartedLedger.root_hash
     assert hashes_before == restartedLedger.tree.hashes
@@ -151,7 +140,7 @@ def test_recover_merkle_tree_from_hash_store(tempdir):
 def test_recover_ledger_new_fields_to_txns_added(tempdir):
     ledger = create_ledger_text_file_storage(
         CompactSerializer(orderedFields), None, tempdir)
-    for d in range(100):
+    for d in range(5):
         ledger.add(random_txn(d))
     updatedTree = ledger.tree
     ledger.stop()
@@ -213,6 +202,66 @@ def test_consistency_verification_on_startup_case_2(tempdir):
         ledger = NoTransactionRecoveryLedger(tree=tree, dataDir=tempdir)
         ledger.recoverTreeFromHashStore()
     ledger.stop()
+
+
+def test_recover_merkle_tree_invalid_hash_store(create_ledger_callable, tempdir,
+                                                txn_serializer, hash_serializer, genesis_txn_file):
+    '''
+    Check that tree can be recovered from txn log if recovering from hash store failed
+    (we have one more txn in hash store than in txn log, so consistency verification fails).
+    '''
+    ledger = create_ledger_callable(
+        txn_serializer, hash_serializer, tempdir, genesis_txn_file)
+    for d in range(5):
+        ledger.add(random_txn(d))
+
+    size_before = ledger.size
+    tree_root_hash_before = ledger.tree.root_hash
+    tree_size_before = ledger.tree.tree_size
+    root_hash_before = ledger.root_hash
+    hashes_before = ledger.tree.hashes
+
+    # add to hash store only
+    ledger._addToTree(ledger.serialize_for_tree(random_txn(50)),
+                      serialized=True)
+    ledger.stop()
+
+    restartedLedger = create_ledger_callable(txn_serializer,
+                                             hash_serializer, tempdir, genesis_txn_file)
+
+    assert size_before == restartedLedger.size
+    assert root_hash_before == restartedLedger.root_hash
+    assert hashes_before == restartedLedger.tree.hashes
+    assert tree_root_hash_before == restartedLedger.tree.root_hash
+    assert tree_size_before == restartedLedger.tree.tree_size
+
+
+def test_recover_merkle_tree_invalid_txn_log(create_ledger_callable, tempdir,
+                                             txn_serializer, hash_serializer, genesis_txn_file):
+    '''
+    Check that tree can be recovered from txn log if recovering from hash store failed
+    (we have one more txn in txn log than in hash store, so consistency verification fails).
+    '''
+    ledger = create_ledger_callable(
+        txn_serializer, hash_serializer, tempdir, genesis_txn_file)
+    for d in range(100):
+        ledger.add(random_txn(d))
+
+    # add to txn log only
+    ledger._addToStore(ledger.serialize_for_txn_log(random_txn(50)),
+                       serialized=True)
+    ledger.stop()
+
+    size_before = ledger.size
+    tree_size_before = ledger.tree.tree_size
+
+    restartedLedger = create_ledger_callable(txn_serializer,
+                                             hash_serializer, tempdir, genesis_txn_file)
+
+    # root hashes will be not the same as before (since we recoverd based on txn log)
+    # the new size is 1 greater than before since we recovered from txn log which contained one more txn
+    assert size_before + 1 == restartedLedger.size
+    assert tree_size_before + 1 == restartedLedger.tree.tree_size
 
 
 def test_start_ledger_without_new_line_appended_to_last_record(tempdir, txn_serializer):

--- a/ledger/test/test_ledger.py
+++ b/ledger/test/test_ledger.py
@@ -204,8 +204,9 @@ def test_consistency_verification_on_startup_case_2(tempdir):
     ledger.stop()
 
 
-def test_recover_merkle_tree_invalid_hash_store(create_ledger_callable, tempdir,
-                                                txn_serializer, hash_serializer, genesis_txn_file):
+def test_recover_merkle_tree_from_txn_log_if_hash_store_runs_ahead(create_ledger_callable, tempdir,
+                                                                   txn_serializer, hash_serializer,
+                                                                   genesis_txn_file):
     '''
     Check that tree can be recovered from txn log if recovering from hash store failed
     (we have one more txn in hash store than in txn log, so consistency verification fails).
@@ -236,8 +237,9 @@ def test_recover_merkle_tree_invalid_hash_store(create_ledger_callable, tempdir,
     assert tree_size_before == restartedLedger.tree.tree_size
 
 
-def test_recover_merkle_tree_invalid_txn_log(create_ledger_callable, tempdir,
-                                             txn_serializer, hash_serializer, genesis_txn_file):
+def test_recover_merkle_tree_from_txn_log_if_hash_store_lags_behind(create_ledger_callable, tempdir,
+                                                                    txn_serializer, hash_serializer,
+                                                                    genesis_txn_file):
     '''
     Check that tree can be recovered from txn log if recovering from hash store failed
     (we have one more txn in txn log than in hash store, so consistency verification fails).


### PR DESCRIPTION
- fixed recovering merkle tree after restart from txn log, if recovering from hash store failed because of consistency verification error (it can be since add to ledger is not atomic operation).

Signed-off-by: ashcherbakov <alexander.sherbakov@dsr-company.com>