### PR TITLE
Context manager for delay rules in stasher

### DIFF
--- a/plenum/test/delayers.py
+++ b/plenum/test/delayers.py
@@ -13,6 +13,7 @@ from plenum.common.types import f
 from plenum.common.util import getCallableName
 from plenum.test.test_client import TestClient
 
+DEFAULT_DELAY = 600
 
 def delayer(seconds, op, senderFilter=None, instFilter: int = None):
     def inner(rx):
@@ -74,83 +75,83 @@ def delayerMethod(method, delay):
     return inner
 
 
-def nom_delay(delay: float, inst_id=None, sender_filter: str=None):
+def nom_delay(delay: float = DEFAULT_DELAY, inst_id=None, sender_filter: str=None):
     # Delayer of NOMINATE requests
     return delayerMsgTuple(
         delay, Nomination, instFilter=inst_id, senderFilter=sender_filter)
 
 
-def prim_delay(delay: float, inst_id=None, sender_filter: str=None):
+def prim_delay(delay: float = DEFAULT_DELAY, inst_id=None, sender_filter: str=None):
     # Delayer of PRIMARY requests
     return delayerMsgTuple(
         delay, Primary, instFilter=inst_id, senderFilter=sender_filter)
 
 
-def rel_delay(delay: float, inst_id=None, sender_filter: str=None):
+def rel_delay(delay: float = DEFAULT_DELAY, inst_id=None, sender_filter: str=None):
     # Delayer of REELECTION requests
     return delayerMsgTuple(
         delay, Reelection, instFilter=inst_id, senderFilter=sender_filter)
 
 
-def ppgDelay(delay: float, sender_filter: str=None):
+def ppgDelay(delay: float = DEFAULT_DELAY, sender_filter: str=None):
     # Delayer of PROPAGATE requests
     return delayerMsgTuple(delay, Propagate, senderFilter=sender_filter)
 
 
-def ppDelay(delay: float, instId: int=None, sender_filter: str=None):
+def ppDelay(delay: float = DEFAULT_DELAY, instId: int=None, sender_filter: str=None):
     # Delayer of PRE-PREPARE requests from a particular instance
     return delayerMsgTuple(delay, PrePrepare, instFilter=instId,
                            senderFilter=sender_filter)
 
 
-def pDelay(delay: float, instId: int=None, sender_filter: str=None):
+def pDelay(delay: float = DEFAULT_DELAY, instId: int=None, sender_filter: str=None):
     # Delayer of PREPARE requests from a particular instance
     return delayerMsgTuple(
         delay, Prepare, instFilter=instId, senderFilter=sender_filter)
 
 
-def cDelay(delay: float, instId: int=None, sender_filter: str=None):
+def cDelay(delay: float = DEFAULT_DELAY, instId: int=None, sender_filter: str=None):
     # Delayer of COMMIT requests from a particular instance
     return delayerMsgTuple(
         delay, Commit, instFilter=instId, senderFilter=sender_filter)
 
 
-def icDelay(delay: float):
+def icDelay(delay: float = DEFAULT_DELAY):
     # Delayer of INSTANCE-CHANGE requests
     return delayerMsgTuple(delay, InstanceChange)
 
 
-def vcd_delay(delay: float):
+def vcd_delay(delay: float = DEFAULT_DELAY):
     # Delayer of VIEW_CHANGE_DONE requests
     return delayerMsgTuple(delay, ViewChangeDone)
 
 
-def lsDelay(delay: float):
+def lsDelay(delay: float = DEFAULT_DELAY):
     # Delayer of LEDGER_STATUSES requests
     return delayerMsgTuple(delay, LedgerStatus)
 
 
-def cpDelay(delay: float):
+def cpDelay(delay: float = DEFAULT_DELAY):
     # Delayer of CONSISTENCY_PROOFS requests
     return delayerMsgTuple(delay, ConsistencyProof)
 
 
-def cqDelay(delay: float):
+def cqDelay(delay: float = DEFAULT_DELAY):
     # Delayer of CATCHUP_REQ requests
     return delayerMsgTuple(delay, CatchupReq)
 
 
-def cr_delay(delay: float):
+def cr_delay(delay: float = DEFAULT_DELAY):
     # Delayer of CATCHUP_REP requests
     return delayerMsgTuple(delay, CatchupRep)
 
 
-def req_delay(delay: float):
+def req_delay(delay: float = DEFAULT_DELAY):
     # Delayer of Request requests
     return delayerMsgTuple(delay, Request)
 
 
-def msg_req_delay(delay: float, types_to_delay: List=None):
+def msg_req_delay(delay: float = DEFAULT_DELAY, types_to_delay: List=None):
     # Delayer of MessageReq messages
     def specific_msgs(msg):
         if isinstance(
@@ -162,7 +163,7 @@ def msg_req_delay(delay: float, types_to_delay: List=None):
     return specific_msgs
 
 
-def msg_rep_delay(delay: float, types_to_delay: List=None):
+def msg_rep_delay(delay: float = DEFAULT_DELAY, types_to_delay: List=None):
     # Delayer of MessageRep messages
     def specific_msgs(msg):
         if isinstance(

--- a/plenum/test/node_request/test_timestamp/test_timestamp_post_view_change.py
+++ b/plenum/test/node_request/test_timestamp/test_timestamp_post_view_change.py
@@ -7,6 +7,7 @@ from plenum.test.node_request.test_timestamp.helper import make_clock_faulty, \
 from plenum.test.test_node import ensureElectionsDone, getNonPrimaryReplicas
 from plenum.test.view_change.helper import ensure_view_change
 from plenum.test.helper import sdk_send_random_and_check, sdk_send_random_requests
+from plenum.test.stasher import delay_rules
 from plenum.test.delayers import icDelay
 
 Max3PCBatchSize = 4
@@ -52,40 +53,31 @@ def test_new_primary_has_wrong_clock(tconf, looper, txnPoolNodeSet,
 
     old_view_no = txnPoolNodeSet[0].viewNo
 
-    # Delay parameters
-    malicious_batch_count = 5
-    malicious_batch_interval = 2
-    instance_change_delay = 1.5 * malicious_batch_count * malicious_batch_interval
-
     # Delay instance change so view change doesn't happen in the middle of this test
-    for node in txnPoolNodeSet:
-        node.nodeIbStasher.delay(icDelay(instance_change_delay))
+    stashers = (n.nodeIbStasher for n in txnPoolNodeSet)
+    with delay_rules(stashers, icDelay()):
+        # Requests are sent
+        for _ in range(5):
+            sdk_send_random_requests(looper,
+                                    sdk_pool_handle,
+                                    sdk_wallet_client,
+                                    count=2)
+            looper.runFor(2)
 
-    # Requests are sent
-    for _ in range(malicious_batch_count):
-        sdk_send_random_requests(looper,
-                                sdk_pool_handle,
-                                sdk_wallet_client,
-                                count=2)
-        looper.runFor(malicious_batch_interval)
+        def chk():
+            for node in txnPoolNodeSet:
+                assert node.viewNo == old_view_no
 
-    def chk():
-        for node in txnPoolNodeSet:
-            assert node.viewNo == old_view_no
+            for node in [n for n in txnPoolNodeSet if n != faulty_node]:
+                # Each non faulty node raises suspicion
+                assert get_timestamp_suspicion_count(node) > susp_counts[node.name]
+                # Ledger does not change
+                assert node.domainLedger.size == ledger_sizes[node.name]
 
-        for node in [n for n in txnPoolNodeSet if n != faulty_node]:
-            # Each non faulty node raises suspicion
-            assert get_timestamp_suspicion_count(node) > susp_counts[node.name]
-            # Ledger does not change
-            assert node.domainLedger.size == ledger_sizes[node.name]
+            assert faulty_node.domainLedger.size == ledger_sizes[faulty_node.name]
 
-        assert faulty_node.domainLedger.size == ledger_sizes[faulty_node.name]
+        looper.run(eventually(chk, retryWait=1))
 
-    looper.run(eventually(chk, retryWait=1))
-
-    # Clear delays
-    for node in txnPoolNodeSet:
-        node.nodeIbStasher.reset_delays_and_process_delayeds()
 
     # Eventually another view change happens
     looper.run(eventually(checkViewNoForNodes, txnPoolNodeSet, old_view_no + 1,

--- a/plenum/test/stasher.py
+++ b/plenum/test/stasher.py
@@ -139,7 +139,18 @@ def delay_rules(stasher, *delayers):
     :param stasher: Instance of Stasher or iterable over instances of stasher
     :param delayers: Delay rule functions to be added to stashers
     """
-    for d in delayers:
-        stasher.delay(d)
+    try:
+        stashers = [s for s in stasher]
+    except TypeError:
+        stashers = [stasher]
+
+    for s in stashers:
+        if not isinstance(s, Stasher):
+            raise TypeError("expected Stasher or Iterable[Stasher] as a first argument")
+
+    for s in stashers:
+        for d in delayers:
+            s.delay(d)
     yield
-    stasher.reset_delays_and_process_delayeds(*(d.__name__ for d in delayers))
+    for s in stashers:
+        s.reset_delays_and_process_delayeds(*(d.__name__ for d in delayers))

--- a/plenum/test/stasher.py
+++ b/plenum/test/stasher.py
@@ -1,4 +1,5 @@
 import time
+from contextlib import contextmanager
 
 from stp_core.common.log import getlogger
 
@@ -108,3 +109,14 @@ class Stasher:
     def reset_delays_and_process_delayeds(self, *names):
         self.resetDelays(*names)
         self.force_unstash(*names)
+
+
+@contextmanager
+def delay_rules(stasher, delayer):
+    stasher.delay(delayer)
+    yield
+    try:
+        stasher.reset_delays_and_process_delayeds(delayer.__name__)
+    except:
+        pass
+

--- a/plenum/test/test_stasher.py
+++ b/plenum/test/test_stasher.py
@@ -116,7 +116,15 @@ def test_delay_rules_can_use_generator_expressions():
     assert delay_twos not in stashers[2].delayRules
 
 
-def test_delay_rules_throws_when_given_stashers_of_wrong_type():
+def test_delay_rules_raise_type_error_when_given_stashers_of_wrong_type():
     with pytest.raises(TypeError):
         with delay_rules(1, delay_twos):
+            pass
+
+    with pytest.raises(TypeError):
+        with delay_rules([1, 2], delay_twos):
+            pass
+
+    with pytest.raises(TypeError):
+        with delay_rules(range(3), delay_twos):
             pass

--- a/plenum/test/test_stasher.py
+++ b/plenum/test/test_stasher.py
@@ -90,3 +90,33 @@ def test_delay_rules_can_use_multiple_delayers():
     assert delay_twos not in s.delayRules
     assert delay_threes not in s.delayRules
 
+
+def test_delay_rules_can_use_multiple_stashers():
+    s1 = Stasher(deque())
+    s2 = Stasher(deque())
+
+    with delay_rules([s1, s2], delay_twos):
+        assert delay_twos in s1.delayRules
+        assert delay_twos in s2.delayRules
+
+    assert delay_twos not in s1.delayRules
+    assert delay_twos not in s2.delayRules
+
+
+def test_delay_rules_can_use_generator_expressions():
+    stashers = [Stasher(deque(), name="{}".format(i)) for i in range(3)]
+
+    with delay_rules((s for s in stashers if s.name != "1"), delay_twos):
+        assert delay_twos in stashers[0].delayRules
+        assert delay_twos not in stashers[1].delayRules
+        assert delay_twos in stashers[2].delayRules
+
+    assert delay_twos not in stashers[0].delayRules
+    assert delay_twos not in stashers[1].delayRules
+    assert delay_twos not in stashers[2].delayRules
+
+
+def test_delay_rules_throws_when_given_stashers_of_wrong_type():
+    with pytest.raises(TypeError):
+        with delay_rules(1, delay_twos):
+            pass

--- a/plenum/test/test_stasher.py
+++ b/plenum/test/test_stasher.py
@@ -71,8 +71,22 @@ def test_delay_rules_return_delayed_items_to_list_on_exit():
 
     with delay_rules(s, delay_twos):
         s.process()
+        assert 1 in q
         assert 2 not in q
         assert 3 not in q
 
+    assert 1 in q
     assert 2 in q
     assert 3 not in q
+
+
+def test_delay_rules_can_use_multiple_delayers():
+    s = Stasher(deque())
+
+    with delay_rules(s, delay_twos, delay_threes):
+        assert delay_twos in s.delayRules
+        assert delay_threes in s.delayRules
+
+    assert delay_twos not in s.delayRules
+    assert delay_threes not in s.delayRules
+

--- a/plenum/test/test_stasher.py
+++ b/plenum/test/test_stasher.py
@@ -3,17 +3,23 @@ from collections import deque
 
 import pytest
 
-from plenum.test.stasher import Stasher
+from plenum.test.stasher import Stasher, delay_rules
+
+
+def delay_twos(item):
+    if item == 2:
+        return 2
+
+
+def delay_threes(item):
+    if item == 3:
+        return 2
 
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-457')
 def test_delay():
-    q = deque([1,2,3])
+    q = deque([1, 2, 3])
     s = Stasher(q, "my-stasher")
-
-    def delay_twos(item):
-        if item == 2:
-            return 2
 
     # Check that relevant items are stashed from deque
     s.delay(delay_twos)
@@ -37,3 +43,36 @@ def test_delay():
     s.resetDelays()
     s.process()
     assert list(q) == [2]
+
+
+def test_delay_rules_enable_delays_on_entry_and_disables_them_on_exit():
+    s = Stasher(deque())
+
+    with delay_rules(s, delay_twos):
+        assert delay_twos in s.delayRules
+
+    assert delay_twos not in s.delayRules
+
+
+def test_delay_rules_dont_touch_other_delays():
+    s = Stasher(deque())
+    s.delay(delay_threes)
+
+    with delay_rules(s, delay_twos):
+        assert delay_threes in s.delayRules
+
+    assert delay_threes in s.delayRules
+
+
+def test_delay_rules_return_delayed_items_to_list_on_exit():
+    q = deque([1, 2, 3])
+    s = Stasher(q)
+    s.delay(delay_threes)
+
+    with delay_rules(s, delay_twos):
+        s.process()
+        assert 2 not in q
+        assert 3 not in q
+
+    assert 2 in q
+    assert 3 not in q


### PR DESCRIPTION
Changes:
- implemented `delay_rules` context manager to simplify delay rules management in tests
- fixed some internals of Stasher and documented possible corner cases
- added default (large) timeouts to most of delay rule functions
- refactored one of existing tests to show example of intended usage of new `delay_rules` context manager

Overall this new context manager should help write less error prone and more deterministic integration tests.

