### PR TITLE
INDY-1251: change math of spikes detection.

### DIFF
--- a/plenum/config.py
+++ b/plenum/config.py
@@ -101,17 +101,19 @@ LatencyWindowSize = 30
 LatencyGraphDuration = 240
 notifierEventTriggeringConfig = {
     'clusterThroughputSpike': {
-        'coefficient': 3,
-        'minCnt': 100,
+        'borders_coeff': 10,
+        'min_cnt': 15,
         'freq': 60,
-        'minActivityThreshold': 2,
+        'min_activity_threshold': 10,
+        'use_weighted_borders_coeff': True,
         'enabled': True
     },
     'nodeRequestSpike': {
-        'coefficient': 3,
-        'minCnt': 100,
+        'borders_coeff': 10,
+        'min_cnt': 15,
         'freq': 60,
-        'minActivityThreshold': 2,
+        'min_activity_threshold': 10,
+        'use_weighted_borders_coeff': True,
         'enabled': True
     }
 }

--- a/plenum/test/plugin/test_notifier_plugin_manager.py
+++ b/plenum/test/plugin/test_notifier_plugin_manager.py
@@ -58,9 +58,10 @@ def testPluginManagerSendMessageUponSuspiciousSpikeFailsOnMinCnt(
     }
     newVal = 10
     config = {
-        'coefficient': 2,
-        'minCnt': 10,
-        'minActivityThreshold': 0,
+        'borders_coeff': 2,
+        'min_cnt': 10,
+        'min_activity_threshold': 0,
+        'use_weighted_borders_coeff': True,
         'enabled': True
     }
     assert pluginManagerWithImportedModules \
@@ -68,7 +69,7 @@ def testPluginManagerSendMessageUponSuspiciousSpikeFailsOnMinCnt(
                                                newVal, config, name, enabled=True) is None
 
 
-def testPluginManagerSendMessageUponSuspiciousSpikeFailsOnCoefficient(
+def testPluginManagerSendMessageUponSuspiciousSpikeFailsOnBordersCoefficient(
         pluginManagerWithImportedModules):
     topic = randomText(10)
     name = randomText(10)
@@ -78,9 +79,10 @@ def testPluginManagerSendMessageUponSuspiciousSpikeFailsOnCoefficient(
     }
     newVal = 15
     config = {
-        'coefficient': 2,
-        'minCnt': 10,
-        'minActivityThreshold': 0,
+        'borders_coeff': 2,
+        'min_cnt': 10,
+        'min_activity_threshold': 0,
+        'use_weighted_borders_coeff': True,
         'enabled': True
     }
     assert pluginManagerWithImportedModules \
@@ -98,9 +100,10 @@ def testPluginManagerSendMessageUponSuspiciousSpike(
     }
     newVal = 25
     config = {
-        'coefficient': 2,
-        'minCnt': 10,
-        'minActivityThreshold': 0,
+        'borders_coeff': 2,
+        'min_cnt': 10,
+        'min_activity_threshold': 0,
+        'use_weighted_borders_coeff': True,
         'enabled': True
     }
     sent, found = pluginManagerWithImportedModules \
@@ -114,19 +117,26 @@ def testNodeSendNodeRequestSpike(pluginManagerWithImportedModules, testNode):
     def mockProcessRequest(obj, inc=1):
         obj.nodeRequestSpikeMonitorData['accum'] += inc
 
+    N = 15
     testNode.config.SpikeEventsEnabled = True
     testNode.config.notifierEventTriggeringConfig['nodeRequestSpike'] = {
-        'coefficient': 3,
-        'minCnt': 1,
+        'borders_coeff': 10,
+        'min_cnt': N,
         'freq': 60,
-        'minActivityThreshold': 0,
+        'min_activity_threshold': 0,
+        'use_weighted_borders_coeff': True,
         'enabled': True
     }
-    mockProcessRequest(testNode)
-    assert testNode.sendNodeRequestSpike() is None
+
+    # The learning period is necessary
+    for _ in range(0, N):
+        mockProcessRequest(testNode)
+        assert testNode.sendNodeRequestSpike() is None
     mockProcessRequest(testNode, 2)
     assert testNode.sendNodeRequestSpike() is None
     mockProcessRequest(testNode, 10)
+    assert testNode.sendNodeRequestSpike() is None
+    mockProcessRequest(testNode, 100)
     sent, found = testNode.sendNodeRequestSpike()
     assert sent == 3
 
@@ -134,14 +144,24 @@ def testNodeSendNodeRequestSpike(pluginManagerWithImportedModules, testNode):
 @pytest.mark.skip(reason='get rid of registry pool')
 def testMonitorSendClusterThroughputSpike(pluginManagerWithImportedModules,
                                           testNode):
-    testNode.monitor.clusterThroughputSpikeMonitorData['accum'] = [1]
-
+    N = 15
     testNode.monitor.notifierEventTriggeringConfig['clusterThroughputSpike'] = {
-        'coefficient': 3, 'minCnt': 1, 'freq': 60, 'minActivityThreshold': 0, 'enabled': True}
-    assert testNode.monitor.sendClusterThroughputSpike() is None
+        'borders_coeff': 10,
+        'min_cnt': N,
+        'freq': 60,
+        'min_activity_threshold': 0,
+        'use_weighted_borders_coeff': True,
+        'enabled': True}
+
+    # The learning period is necessary
+    for _ in range(0, N):
+        testNode.monitor.clusterThroughputSpikeMonitorData['accum'] = [1]
+        assert testNode.monitor.sendClusterThroughputSpike() is None
     testNode.monitor.clusterThroughputSpikeMonitorData['accum'] = [2]
     assert testNode.monitor.sendClusterThroughputSpike() is None
-    testNode.monitor.clusterThroughputSpikeMonitorData['accum'] = [4.6]
+    testNode.monitor.clusterThroughputSpikeMonitorData['accum'] = [4, 6]
+    assert testNode.monitor.sendClusterThroughputSpike() is None
+    testNode.monitor.clusterThroughputSpikeMonitorData['accum'] = [100]
     sent, found = testNode.monitor.sendClusterThroughputSpike()
     assert sent == 3
 
@@ -151,7 +171,11 @@ def test_suspicious_spike_check_disabled_config(pluginManagerWithImportedModules
     name = randomText(10)
     hdata = {'value': 10, 'cnt': 10}
     nval = 25
-    config = {'coefficient': 2, 'minCnt': 10, 'minActivityThreshold': 2, 'enabled': True}
+    config = {'borders_coeff': 2,
+              'min_cnt': 10,
+              'min_activity_threshold': 2,
+              'use_weighted_borders_coeff': True,
+              'enabled': True}
 
     sent, _ = pluginManagerWithImportedModules.sendMessageUponSuspiciousSpike(topic, hdata, nval,
                                                                               config, name, enabled=True)
@@ -169,7 +193,11 @@ def test_suspicious_spike_check_disabled_func(pluginManagerWithImportedModules):
     name = randomText(10)
     hdata = {'value': 10, 'cnt': 10}
     nval = 25
-    config = {'coefficient': 2, 'minCnt': 10, 'minActivityThreshold': 2, 'enabled': True}
+    config = {'borders_coeff': 2,
+              'min_cnt': 10,
+              'min_activity_threshold': 2,
+              'use_weighted_borders_coeff': True,
+              'enabled': True}
 
     sent, _ = pluginManagerWithImportedModules.sendMessageUponSuspiciousSpike(topic, hdata, nval,
                                                                               config, name, enabled=True)
@@ -181,19 +209,49 @@ def test_suspicious_spike_check_disabled_func(pluginManagerWithImportedModules):
                                                                            config, name, enabled=False) is None
 
 
+def test_suspicious_spike_check_weighted_borders(pluginManagerWithImportedModules):
+    topic = randomText(10)
+    name = randomText(10)
+    hdata = {'value': 100, 'cnt': 100}
+    nval = 700
+    config = {'borders_coeff': 10,
+              'min_cnt': 10,
+              'min_activity_threshold': 10,
+              'use_weighted_borders_coeff': True,
+              'enabled': True}
+
+    sent, _ = pluginManagerWithImportedModules.sendMessageUponSuspiciousSpike(topic, hdata, nval,
+                                                                              config, name, enabled=True)
+    assert sent == 3
+
+    hdata['value'] = 100
+    hdata['cnt'] = 100
+    config['use_weighted_borders_coeff'] = False
+    assert pluginManagerWithImportedModules.sendMessageUponSuspiciousSpike(topic, hdata, nval,
+                                                                           config, name, enabled=True) is None
+
+
 def test_no_message_from_0_to_1(pluginManagerWithImportedModules):
     topic = randomText(10)
     name = randomText(10)
     hdata = {'value': 0, 'cnt': 10}
     nval = 1
-    config = {'coefficient': 2, 'minCnt': 10, 'minActivityThreshold': 0, 'enabled': True}
+    config = {'borders_coeff': 2,
+              'min_cnt': 10,
+              'min_activity_threshold': 0,
+              'use_weighted_borders_coeff': True,
+              'enabled': True}
 
     sent, _ = pluginManagerWithImportedModules.sendMessageUponSuspiciousSpike(topic, hdata, nval,
                                                                               config, name, enabled=True)
     assert sent == 3
 
     hdata = {'value': 0, 'cnt': 10}
-    config = {'coefficient': 2, 'minCnt': 10, 'minActivityThreshold': 2, 'enabled': True}
+    config = {'borders_coeff': 2,
+              'min_cnt': 10,
+              'min_activity_threshold': 2,
+              'use_weighted_borders_coeff': True,
+              'enabled': True}
     assert pluginManagerWithImportedModules.sendMessageUponSuspiciousSpike(topic, hdata, nval,
                                                                            config, name, enabled=True) is None
 
@@ -203,13 +261,21 @@ def test_no_message_from_1_to_0(pluginManagerWithImportedModules):
     name = randomText(10)
     hdata = {'value': 1, 'cnt': 10}
     nval = 0
-    config = {'coefficient': 2, 'minCnt': 10, 'minActivityThreshold': 0, 'enabled': True}
+    config = {'borders_coeff': 2,
+              'min_cnt': 10,
+              'min_activity_threshold': 0,
+              'use_weighted_borders_coeff': True,
+              'enabled': True}
 
     sent, _ = pluginManagerWithImportedModules.sendMessageUponSuspiciousSpike(topic, hdata, nval,
                                                                               config, name, enabled=True)
     assert sent == 3
 
     hdata = {'value': 1, 'cnt': 10}
-    config = {'coefficient': 2, 'minCnt': 10, 'minActivityThreshold': 2, 'enabled': True}
+    config = {'borders_coeff': 2,
+              'min_cnt': 10,
+              'min_activity_threshold': 2,
+              'use_weighted_borders_coeff': True,
+              'enabled': True}
     assert pluginManagerWithImportedModules.sendMessageUponSuspiciousSpike(topic, hdata, nval,
                                                                            config, name, enabled=True) is None


### PR DESCRIPTION
Changed math of node request and cluster throughtput spikes detection.
The main changes:
 * Now smothing constant (alpha) is really constant as declares exponential
   moving average (EMA), alpha = 2 / (N + 1), where N is a minimal count of
   passed periods needed for comparison of expected value and real value, a.g.
   learning period. For now N = 15, so alpha = 0.125.
 * Rised min activity from 2 to 10, a.g. we start to compare expected and real
   values if we handle more than 10 request per time period, that now is set
   to 60 secs (10 requests per minute).
 * Rised borders coefficient to extend the lower and higher borders when observed
   value is treated as normal relative to expected value, previous border coefficient = 3:
    - lower border:  expected_val / 3
    - higher border: expected_val * 3
   new borders coefficient = 10:
    - lower border:  expected_val / 10
    - higher border: expected_val * 10
   Also implemented weighted borders coefficient. It means adaptation of
   borders coeffitient to larger values using formula:
      weighted_borders_coef = borders_coef / log(expected_val)
   Such approach allows to lower borders for larger values. This
   functionality is optional and enabled by default.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>