### PR TITLE
INDY-1287: fix base58 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     install_requires=['jsonpickle', 'ujson==1.33',
                       'prompt_toolkit==0.57', 'pygments',
                       'rlp', 'sha3', 'leveldb',
-                      'ioflo==1.5.4', 'semver', 'base58==1.0.0', 'orderedset',
+                      'ioflo==1.5.4', 'semver', 'base58==0.2.5', 'orderedset',
                       'sortedcontainers==1.5.7', 'psutil', 'pip<10.0.0',
                       'portalocker==0.5.7', 'pyzmq', 'libnacl==1.6.1',
                       'six==1.11.0', 'psutil', 'intervaltree',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     install_requires=['jsonpickle', 'ujson==1.33',
                       'prompt_toolkit==0.57', 'pygments',
                       'rlp', 'sha3', 'leveldb',
-                      'ioflo==1.5.4', 'semver', 'base58', 'orderedset',
+                      'ioflo==1.5.4', 'semver', 'base58==1.0.0', 'orderedset',
                       'sortedcontainers==1.5.7', 'psutil', 'pip<10.0.0',
                       'portalocker==0.5.7', 'pyzmq', 'libnacl==1.6.1',
                       'six==1.11.0', 'psutil', 'intervaltree',


### PR DESCRIPTION
A new version of the base58 1.0.0 was released. The format of the response of the b58encode() was changed from string to bytes.

Changes:
-fix base58 0.2.5 version 