### PR TITLE
INDY-1273/1275: Log rotation improvements

### DIFF
--- a/plenum/config.py
+++ b/plenum/config.py
@@ -136,9 +136,9 @@ CatchupTransactionsTimeout = 6
 # Log configuration
 logRotationWhen = 'W6'
 logRotationInterval = 1
-logRotationBackupCount = 50
+logRotationBackupCount = 300
 logRotationMaxBytes = 100 * 1024 * 1024
-logRotationCompress = True
+logRotationCompression = "xz"
 logFormat = '{asctime:s} | {levelname:8s} | {filename:20s} ({lineno: >4}) | {funcName:s} | {message:s}'
 logFormatStyle = '{'
 logLevel = logging.NOTSET

--- a/plenum/config.py
+++ b/plenum/config.py
@@ -134,8 +134,6 @@ ConsistencyProofsTimeout = 5
 CatchupTransactionsTimeout = 6
 
 # Log configuration
-logRotationWhen = 'W6'
-logRotationInterval = 1
 logRotationBackupCount = 300
 logRotationMaxBytes = 100 * 1024 * 1024
 logRotationCompression = "xz"

--- a/plenum/test/test_log_rotation.py
+++ b/plenum/test/test_log_rotation.py
@@ -2,6 +2,7 @@ import os
 import logging
 import collections
 import pytest
+import importlib
 
 from stp_core.common.logging.CompressingFileHandler \
     import CompressingFileHandler
@@ -20,6 +21,13 @@ def test_default_log_rotation_config_is_correct(tdir_for_func):
 
     # Assert this doesn't fail
     logger.enableFileLogging(log_file)
+
+
+def test_dynamic_log_import_works_as_expected():
+    # Assert that nothing here fails
+    log_module = importlib.import_module("stp_core.common.log")
+    logger = log_module.getlogger()
+    logger.info("test")
 
 
 def test_log_file_matcher_works_as_expected(tdir_for_func, log_compression):

--- a/plenum/test/test_log_rotation.py
+++ b/plenum/test/test_log_rotation.py
@@ -2,7 +2,6 @@ import os
 import logging
 import time
 import collections
-import gzip
 import pytest
 
 from stp_core.common.logging.TimeAndSizeRotatingFileHandler \

--- a/plenum/test/test_log_rotation.py
+++ b/plenum/test/test_log_rotation.py
@@ -25,8 +25,7 @@ def test_default_log_rotation_config_is_correct(tdir_for_func):
 def test_log_file_matcher_works_as_expected(tdir_for_func, log_compression):
     logDirPath = tdir_for_func
     logFile = os.path.join(logDirPath, "log")
-    handler = CompressingFileHandler(
-        logFile, delay=True, interval=1, when='s', compression=log_compression)
+    handler = CompressingFileHandler(logFile, delay=True, compression=log_compression)
 
     assert handler.log_pattern.match("log")
     assert handler.log_pattern.match("log.42")
@@ -51,8 +50,7 @@ def test_time_log_rotation(tdir_for_func, log_compression):
     logger = logging.getLogger('test_time_log_rotation-logger')
 
     logger.setLevel(logging.DEBUG)
-    handler = CompressingFileHandler(
-        logFile, interval=1, when='s', compression=log_compression)
+    handler = CompressingFileHandler(logFile, compression=log_compression)
     logger.addHandler(handler)
     for i in range(3):
         time.sleep(1)
@@ -68,8 +66,7 @@ def test_size_log_rotation(tdir_for_func, log_compression):
     logger = logging.getLogger('test_time_log_rotation-logger')
 
     logger.setLevel(logging.DEBUG)
-    handler = CompressingFileHandler(
-        logFile, maxBytes=(4 + len(os.linesep)) * 4 + 1, compression=log_compression)
+    handler = CompressingFileHandler(logFile, maxBytes=(4 + len(os.linesep)) * 4 + 1, compression=log_compression)
     logger.addHandler(handler)
     for i in range(20):
         logger.debug("line")
@@ -86,8 +83,7 @@ def test_time_and_size_log_rotation(tdir_for_func, log_compression):
     logger = logging.getLogger('test_time_and_size_log_rotation-logger')
 
     logger.setLevel(logging.DEBUG)
-    handler = CompressingFileHandler(
-        logFile, maxBytes=(4 + len(os.linesep)) * 4 + 1, interval=1, when="s", compression=log_compression)
+    handler = CompressingFileHandler(logFile, maxBytes=(4 + len(os.linesep)) * 4 + 1, compression=log_compression)
     logger.addHandler(handler)
 
     for i in range(20):
@@ -116,10 +112,8 @@ def test_time_and_size_log_rotation1(tdir_for_func, log_compression):
     record_text = 'line'
     record_length = len(record_text) + len(str(record_count))
 
-    handler = CompressingFileHandler(
-        logFile,
-        maxBytes=(record_length + len(os.linesep)) * record_per_file + 1,
-        interval=1, when="h", backupCount=backup_count, utc=True, compression=log_compression)
+    handler = CompressingFileHandler(logFile, maxBytes=(record_length + len(os.linesep)) * record_per_file + 1,
+                                     backupCount=backup_count, compression=log_compression)
     logger.addHandler(handler)
 
     for i in range(1, record_count + 1):

--- a/plenum/test/test_log_rotation.py
+++ b/plenum/test/test_log_rotation.py
@@ -4,8 +4,8 @@ import time
 import collections
 import pytest
 
-from stp_core.common.logging.TimeAndSizeRotatingFileHandler \
-    import TimeAndSizeRotatingFileHandler
+from stp_core.common.logging.CompressingFileHandler \
+    import CompressingFileHandler
 from stp_core.common.log import Logger
 
 
@@ -25,7 +25,7 @@ def test_default_log_rotation_config_is_correct(tdir_for_func):
 def test_log_file_matcher_works_as_expected(tdir_for_func, log_compression):
     logDirPath = tdir_for_func
     logFile = os.path.join(logDirPath, "log")
-    handler = TimeAndSizeRotatingFileHandler(
+    handler = CompressingFileHandler(
         logFile, delay=True, interval=1, when='s', compression=log_compression)
 
     assert handler.log_pattern.match("log")
@@ -51,7 +51,7 @@ def test_time_log_rotation(tdir_for_func, log_compression):
     logger = logging.getLogger('test_time_log_rotation-logger')
 
     logger.setLevel(logging.DEBUG)
-    handler = TimeAndSizeRotatingFileHandler(
+    handler = CompressingFileHandler(
         logFile, interval=1, when='s', compression=log_compression)
     logger.addHandler(handler)
     for i in range(3):
@@ -68,7 +68,7 @@ def test_size_log_rotation(tdir_for_func, log_compression):
     logger = logging.getLogger('test_time_log_rotation-logger')
 
     logger.setLevel(logging.DEBUG)
-    handler = TimeAndSizeRotatingFileHandler(
+    handler = CompressingFileHandler(
         logFile, maxBytes=(4 + len(os.linesep)) * 4 + 1, compression=log_compression)
     logger.addHandler(handler)
     for i in range(20):
@@ -86,7 +86,7 @@ def test_time_and_size_log_rotation(tdir_for_func, log_compression):
     logger = logging.getLogger('test_time_and_size_log_rotation-logger')
 
     logger.setLevel(logging.DEBUG)
-    handler = TimeAndSizeRotatingFileHandler(
+    handler = CompressingFileHandler(
         logFile, maxBytes=(4 + len(os.linesep)) * 4 + 1, interval=1, when="s", compression=log_compression)
     logger.addHandler(handler)
 
@@ -116,7 +116,7 @@ def test_time_and_size_log_rotation1(tdir_for_func, log_compression):
     record_text = 'line'
     record_length = len(record_text) + len(str(record_count))
 
-    handler = TimeAndSizeRotatingFileHandler(
+    handler = CompressingFileHandler(
         logFile,
         maxBytes=(record_length + len(os.linesep)) * record_per_file + 1,
         interval=1, when="h", backupCount=backup_count, utc=True, compression=log_compression)
@@ -139,6 +139,6 @@ def test_time_and_size_log_rotation1(tdir_for_func, log_compression):
     assert all(handler.log_pattern.match(name) for name in os.listdir(log_dir_path))
     assert len(os.listdir(log_dir_path)) == (backup_count + 1)
     for file_name in os.listdir(log_dir_path):
-        with TimeAndSizeRotatingFileHandler._open_log(os.path.join(log_dir_path, file_name), "rt") as file:
+        with CompressingFileHandler._open_log(os.path.join(log_dir_path, file_name), "rt") as file:
             for line in file.readlines():
                 assert line.strip() in circ_buffer_set

--- a/plenum/test/test_log_rotation.py
+++ b/plenum/test/test_log_rotation.py
@@ -35,6 +35,7 @@ def test_time_log_rotation(tdir_for_func, log_compression):
     for i in range(3):
         time.sleep(1)
         logger.debug("line")
+    handler._finish_compression()
     assert len(os.listdir(logDirPath)) == 4  # initial + 3 new
 
 
@@ -50,6 +51,7 @@ def test_size_log_rotation(tdir_for_func, log_compression):
     for i in range(20):
         logger.debug("line")
     handler.flush()
+    handler._finish_compression()
 
     assert len(os.listdir(logDirPath)) == 5
 
@@ -70,6 +72,8 @@ def test_time_and_size_log_rotation(tdir_for_func, log_compression):
     for i in range(3):
         time.sleep(1)
         logger.debug("line")
+
+    handler._finish_compression()
 
     assert len(os.listdir(logDirPath)) == 8
 
@@ -102,6 +106,8 @@ def test_time_and_size_log_rotation1(tdir_for_func, log_compression):
             # waiting since last modified time cannot offer good enough
             # precision
             time.sleep(.5)
+
+    handler._finish_compression()
 
     circ_buffer_set = set(cir_buffer)
     assert len(cir_buffer) == len(circ_buffer_set)

--- a/stp_core/common/log.py
+++ b/stp_core/common/log.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 import time
-from stp_core.common.logging.TimeAndSizeRotatingFileHandler import TimeAndSizeRotatingFileHandler
+from stp_core.common.logging.CompressingFileHandler import CompressingFileHandler
 from stp_core.common.util import Singleton
 from stp_core.common.logging.handlers import CliHandler
 from stp_core.common.config.util import getConfig
@@ -92,7 +92,7 @@ class Logger(metaclass=Singleton):
         d = os.path.dirname(filename)
         if not os.path.exists(d):
             os.makedirs(d)
-        new = TimeAndSizeRotatingFileHandler(
+        new = CompressingFileHandler(
             filename,
             when=self._config.logRotationWhen,
             interval=self._config.logRotationInterval,

--- a/stp_core/common/log.py
+++ b/stp_core/common/log.py
@@ -2,7 +2,7 @@ import inspect
 import logging
 import os
 import sys
-from ioflo.base.consoling import getConsole, Console
+import time
 from stp_core.common.logging.TimeAndSizeRotatingFileHandler import TimeAndSizeRotatingFileHandler
 from stp_core.common.util import Singleton
 from stp_core.common.logging.handlers import CliHandler
@@ -64,6 +64,7 @@ class Logger(metaclass=Singleton):
         self._clearAllHandlers()
         self._format = logging.Formatter(fmt=self._config.logFormat,
                                          style=self._config.logFormatStyle)
+        self._format.converter = time.gmtime
 
         if self._config.enableStdOutLogging:
             self.enableStdLogging()

--- a/stp_core/common/log.py
+++ b/stp_core/common/log.py
@@ -98,7 +98,7 @@ class Logger(metaclass=Singleton):
             backupCount=self._config.logRotationBackupCount,
             utc=True,
             maxBytes=self._config.logRotationMaxBytes,
-            compress=self._config.logRotationCompress)
+            compression=self._config.logRotationCompression)
         self._setHandler('file', new)
 
     def _setHandler(self, typ: str, new_handler):

--- a/stp_core/common/log.py
+++ b/stp_core/common/log.py
@@ -92,14 +92,9 @@ class Logger(metaclass=Singleton):
         d = os.path.dirname(filename)
         if not os.path.exists(d):
             os.makedirs(d)
-        new = CompressingFileHandler(
-            filename,
-            when=self._config.logRotationWhen,
-            interval=self._config.logRotationInterval,
-            backupCount=self._config.logRotationBackupCount,
-            utc=True,
-            maxBytes=self._config.logRotationMaxBytes,
-            compression=self._config.logRotationCompression)
+        new = CompressingFileHandler(filename, maxBytes=self._config.logRotationMaxBytes,
+                                     backupCount=self._config.logRotationBackupCount,
+                                     compression=self._config.logRotationCompression)
         self._setHandler('file', new)
 
     def _setHandler(self, typ: str, new_handler):

--- a/stp_core/common/logging/CompressingFileHandler.py
+++ b/stp_core/common/logging/CompressingFileHandler.py
@@ -9,7 +9,7 @@ from logging.handlers import TimedRotatingFileHandler
 from logging.handlers import RotatingFileHandler
 
 
-class TimeAndSizeRotatingFileHandler(TimedRotatingFileHandler, RotatingFileHandler):
+class CompressingFileHandler(TimedRotatingFileHandler, RotatingFileHandler):
 
     def __init__(self, filename, when='h', interval=1, backupCount=0,
                  encoding=None, delay=False, utc=False, atTime=None,
@@ -47,7 +47,7 @@ class TimeAndSizeRotatingFileHandler(TimedRotatingFileHandler, RotatingFileHandl
         os.rename(source, tmp_file)
 
         self._finish_compression()
-        self.compressor = Process(target=TimeAndSizeRotatingFileHandler._recompress, args=(tmp_file, dest))
+        self.compressor = Process(target=CompressingFileHandler._recompress, args=(tmp_file, dest))
         self.compressor.start()
 
     def rotation_filename(self, default_name: str):
@@ -100,7 +100,7 @@ class TimeAndSizeRotatingFileHandler(TimedRotatingFileHandler, RotatingFileHandl
 
     @staticmethod
     def _open_log(filename, mode):
-        compression = TimeAndSizeRotatingFileHandler._file_compression(filename)
+        compression = CompressingFileHandler._file_compression(filename)
         if compression == "gz":
             return gzip.open(filename, mode)
         if compression == "xz":
@@ -109,8 +109,8 @@ class TimeAndSizeRotatingFileHandler(TimedRotatingFileHandler, RotatingFileHandl
 
     @staticmethod
     def _recompress(source, dest):
-        with TimeAndSizeRotatingFileHandler._open_log(source, 'rb') as f_in, \
-                TimeAndSizeRotatingFileHandler._open_log(dest, 'wb') as f_out:
+        with CompressingFileHandler._open_log(source, 'rb') as f_in, \
+                CompressingFileHandler._open_log(dest, 'wb') as f_out:
             f_out.write(f_in.read())
         os.remove(source)
 

--- a/stp_core/common/logging/CompressingFileHandler.py
+++ b/stp_core/common/logging/CompressingFileHandler.py
@@ -92,21 +92,9 @@ class CompressingFileHandler(RotatingFileHandler):
         if self.backupCount == 0:
             return
 
-        log_files = [(name, idx) for name, idx in self._log_files()]
-        if len(log_files) == 0:
-            return
-
-        log_files, log_indexes = zip(*log_files)
-        keep_count = self.backupCount
-
-        # This can happen when compression is still in progress
-        if max(log_indexes) < self.max_index:
-            keep_count -= 1
-
-        if len(log_files) <= keep_count:
-            return
-
-        log_files = list(log_files)
-        log_files.sort(key=os.path.getmtime)
-        for file in log_files[:-keep_count]:
+        for file, idx in self._log_files():
+            if idx == 0:
+                continue
+            if idx > self.max_index - self.backupCount + 1:
+                continue
             os.remove(file)

--- a/stp_core/common/logging/CompressingFileHandler.py
+++ b/stp_core/common/logging/CompressingFileHandler.py
@@ -5,20 +5,14 @@ import lzma
 from logging import Logger
 from datetime import datetime, timedelta
 from multiprocessing import Process
-from logging.handlers import TimedRotatingFileHandler
 from logging.handlers import RotatingFileHandler
 
 
-class CompressingFileHandler(TimedRotatingFileHandler, RotatingFileHandler):
+class CompressingFileHandler(RotatingFileHandler):
 
-    def __init__(self, filename, when='h', interval=1, backupCount=0,
-                 encoding=None, delay=False, utc=False, atTime=None,
-                 maxBytes=0, compression=None):
+    def __init__(self, filename, maxBytes=0, backupCount=0, delay=False, compression=None):
+        RotatingFileHandler.__init__(self, filename, maxBytes=maxBytes, backupCount=backupCount, delay=delay)
 
-        TimedRotatingFileHandler.__init__(self, filename, when, interval,
-                                          backupCount, encoding, delay,
-                                          utc, atTime)
-        self.maxBytes = maxBytes
         self.compression = compression
         self.compressor = None
 
@@ -27,10 +21,6 @@ class CompressingFileHandler(TimedRotatingFileHandler, RotatingFileHandler):
 
         file_indexes = [idx for name, idx in self._log_files()]
         self.max_index = max(file_indexes) if file_indexes else 0
-
-    def shouldRollover(self, record):
-        return bool(TimedRotatingFileHandler.shouldRollover(self, record)) or \
-            bool(RotatingFileHandler.shouldRollover(self, record))
 
     def rotate(self, source, dest):
         self.max_index += 1

--- a/stp_core/common/logging/CompressingFileHandler.py
+++ b/stp_core/common/logging/CompressingFileHandler.py
@@ -61,16 +61,8 @@ class CompressingFileHandler(RotatingFileHandler):
         if delta < 1.0:
             return
 
-        msg = "Needed to join log compression process which took {} seconds in main process".format(delta)
-        try:
-            logger = importlib.import_module("stp_core.common.log").getlogger()
-            logger.warning(msg)
-        except ImportError as e:
-            print("ERROR: Failed to dynamically import stp_core.common.log")
-            print("WARNING: {}".format(msg))
-        except AttributeError as e:
-            print("ERROR: Failed to find getlogger() in stp_core.common.log")
-            print("WARNING: {}".format(msg))
+        logger = importlib.import_module("stp_core.common.log").getlogger()
+        logger.warning("Needed to join log compression process which took {} seconds in main process".format(delta))
 
     def _log_files(self):
         log_dir = os.path.dirname(self.baseFilename)

--- a/stp_core/common/logging/TimeAndSizeRotatingFileHandler.py
+++ b/stp_core/common/logging/TimeAndSizeRotatingFileHandler.py
@@ -30,7 +30,7 @@ class TimeAndSizeRotatingFileHandler(TimedRotatingFileHandler, RotatingFileHandl
 
     def shouldRollover(self, record):
         return bool(TimedRotatingFileHandler.shouldRollover(self, record)) or \
-               bool(RotatingFileHandler.shouldRollover(self, record))
+            bool(RotatingFileHandler.shouldRollover(self, record))
 
     def rotate(self, source, dest):
         self.max_index += 1
@@ -64,10 +64,10 @@ class TimeAndSizeRotatingFileHandler(TimedRotatingFileHandler, RotatingFileHandl
             return
 
         # logger = Logger()
-        now = datetime.now()
+        # now = datetime.now()
         # logger.warning("Log compression in progress while new log needs to be compressed, joining process")
         self.compressor.join()
-        delta = datetime.now() - now
+        # delta = datetime.now() - now
         # if delta > timedelta(2):
         #     logger.warning("Waiting for log compression worker took more than 2 seconds")
         self.compressor = None
@@ -84,8 +84,10 @@ class TimeAndSizeRotatingFileHandler(TimedRotatingFileHandler, RotatingFileHandl
 
     @staticmethod
     def _file_compression(filename):
-        if filename.endswith(".gz"): return "gz"
-        if filename.endswith(".xz"): return "xz"
+        if filename.endswith(".gz"):
+            return "gz"
+        if filename.endswith(".xz"):
+            return "xz"
         return None
 
     @staticmethod
@@ -99,8 +101,10 @@ class TimeAndSizeRotatingFileHandler(TimedRotatingFileHandler, RotatingFileHandl
     @staticmethod
     def _open_log(filename, mode):
         compression = TimeAndSizeRotatingFileHandler._file_compression(filename)
-        if compression == "gz": return gzip.open(filename, mode)
-        if compression == "xz": return lzma.open(filename, mode)
+        if compression == "gz":
+            return gzip.open(filename, mode)
+        if compression == "xz":
+            return lzma.open(filename, mode)
         return open(filename, mode)
 
     @staticmethod

--- a/stp_core/common/logging/TimeAndSizeRotatingFileHandler.py
+++ b/stp_core/common/logging/TimeAndSizeRotatingFileHandler.py
@@ -1,5 +1,6 @@
 import os
 import gzip
+import lzma
 from logging.handlers import TimedRotatingFileHandler
 from logging.handlers import RotatingFileHandler
 
@@ -8,28 +9,25 @@ class TimeAndSizeRotatingFileHandler(TimedRotatingFileHandler, RotatingFileHandl
 
     def __init__(self, filename, when='h', interval=1, backupCount=0,
                  encoding=None, delay=False, utc=False, atTime=None,
-                 maxBytes=0, compress=False):
+                 maxBytes=0, compression=None):
 
         TimedRotatingFileHandler.__init__(self, filename, when, interval,
                                           backupCount, encoding, delay,
                                           utc, atTime)
         self.maxBytes = maxBytes
-        self.compress = compress
+        self.compression = compression
 
     def shouldRollover(self, record):
         return bool(TimedRotatingFileHandler.shouldRollover(self, record)) or \
-            bool(RotatingFileHandler.shouldRollover(self, record))
+               bool(RotatingFileHandler.shouldRollover(self, record))
 
     def rotate(self, source, dest):
-        source_gz = source.endswith(".gz")
-        dest_gz = dest.endswith(".gz")
-        if source_gz == dest_gz:
+        source_compression = self._file_compression(source)
+        dest_compression = self._file_compression(dest)
+        if source_compression == dest_compression:
             os.rename(source, dest)
             return
-        # Assuming that not source_gz and dest_gz
-        with open(source, 'rb') as f_in, gzip.open(dest, 'wb') as f_out:
-            f_out.writelines(f_in)
-        os.remove(source)
+        self._recompress(source, dest)
 
     def rotation_filename(self, default_name: str):
         compressed_name = self._compressed_filename(default_name)
@@ -49,13 +47,33 @@ class TimeAndSizeRotatingFileHandler(TimedRotatingFileHandler, RotatingFileHandl
         return self._compressed_filename("{}.{}".format(default_name, maxIndex + 1))
 
     def _compressed_filename(self, file_name):
-        return "{}.gz".format(file_name) if self.compress else file_name
+        return "{}.{}".format(file_name, self.compression) if self.compression else file_name
+
+    @staticmethod
+    def _file_compression(file_name):
+        if file_name.endswith(".gz"): return "gz"
+        if file_name.endswith(".xz"): return "xz"
+        return None
+
+    @staticmethod
+    def _open_log(file_name, mode):
+        compression = TimeAndSizeRotatingFileHandler._file_compression(file_name)
+        if compression == "gz": return gzip.open(file_name, mode)
+        if compression == "xz": return lzma.open(file_name, mode)
+        return open(file_name, mode)
+
+    @staticmethod
+    def _recompress(source, dest):
+        with TimeAndSizeRotatingFileHandler._open_log(source, 'rb') as f_in, \
+                TimeAndSizeRotatingFileHandler._open_log(dest, 'wb') as f_out:
+            f_out.write(f_in.read())
+        os.remove(source)
 
     @staticmethod
     def _file_index(file_name):
         split = file_name.split(".")
         index = split[-1]
-        if index == "gz":
+        if index in ["gz", "xz"]:
             index = split[-2]
         try:
             return int(index)
@@ -79,6 +97,8 @@ class TimeAndSizeRotatingFileHandler(TimedRotatingFileHandler, RotatingFileHandl
             if fileName[:plen] == prefix:
                 suffix = fileName[plen:]
                 if suffix.endswith(".gz"):
+                    suffix = suffix[:-3]
+                if suffix.endswith(".xz"):
                     suffix = suffix[:-3]
                 if self.extMatch.match(suffix):
                     result.append(os.path.join(dirName, fileName))

--- a/stp_core/common/logging/TimeAndSizeRotatingFileHandler.py
+++ b/stp_core/common/logging/TimeAndSizeRotatingFileHandler.py
@@ -1,4 +1,5 @@
 import os
+import re
 import gzip
 import lzma
 from logging import Logger
@@ -6,7 +7,6 @@ from datetime import datetime, timedelta
 from multiprocessing import Process
 from logging.handlers import TimedRotatingFileHandler
 from logging.handlers import RotatingFileHandler
-
 
 
 class TimeAndSizeRotatingFileHandler(TimedRotatingFileHandler, RotatingFileHandler):
@@ -22,43 +22,38 @@ class TimeAndSizeRotatingFileHandler(TimedRotatingFileHandler, RotatingFileHandl
         self.compression = compression
         self.compressor = None
 
+        log_prefix = os.path.basename(self.baseFilename)
+        self.log_pattern = re.compile("^{}(?:|\.(\d+)(?:|\.gz|\.xz))$".format(log_prefix))
+
+        file_indexes = [idx for name, idx in self._log_files()]
+        self.max_index = max(file_indexes) if file_indexes else 0
+
     def shouldRollover(self, record):
         return bool(TimedRotatingFileHandler.shouldRollover(self, record)) or \
                bool(RotatingFileHandler.shouldRollover(self, record))
 
     def rotate(self, source, dest):
+        self.max_index += 1
+
         source_compression = self._file_compression(source)
         dest_compression = self._file_compression(dest)
         if source_compression == dest_compression:
             os.rename(source, dest)
             return
 
+        tmp_dir, tmp_file = os.path.split(dest)
+        tmp_file = self._file_update_compression(tmp_file, source_compression)
+        tmp_file = os.path.join(tmp_dir, ".tmp_{}".format(tmp_file))
+        os.rename(source, tmp_file)
+
         self._finish_compression()
-        self.compressor = Process(target=TimeAndSizeRotatingFileHandler._recompress, args=(source, dest))
+        self.compressor = Process(target=TimeAndSizeRotatingFileHandler._recompress, args=(tmp_file, dest))
         self.compressor.start()
-        # self._finish_compression()
 
     def rotation_filename(self, default_name: str):
-        self._finish_compression()
-
-        compressed_name = self._compressed_filename(default_name)
-        if not os.path.exists(compressed_name):
-            return compressed_name
-
-        dir = os.path.dirname(default_name)
-        defaultFileName = os.path.basename(default_name)
-        fileNames = os.listdir(dir)
-
-        maxIndex = -1
-        for fileName in fileNames:
-            if fileName.startswith(defaultFileName):
-                index = self._file_index(fileName)
-                if index > maxIndex:
-                    maxIndex = index
-        return self._compressed_filename("{}.{}".format(default_name, maxIndex + 1))
-
-    def _compressed_filename(self, file_name):
-        return "{}.{}".format(file_name, self.compression) if self.compression else file_name
+        log_name = "{}.{}".format(self.baseFilename, self.max_index + 1)
+        log_name = self._file_update_compression(log_name, self.compression)
+        return log_name
 
     def _finish_compression(self):
         if self.compressor is None:
@@ -68,27 +63,45 @@ class TimeAndSizeRotatingFileHandler(TimedRotatingFileHandler, RotatingFileHandl
             self.compressor = None
             return
 
-        #logger = Logger()
+        # logger = Logger()
         now = datetime.now()
-        #logger.warning("Log compression in progress while new log needs to be compressed, joining process")
+        # logger.warning("Log compression in progress while new log needs to be compressed, joining process")
         self.compressor.join()
         delta = datetime.now() - now
-        #if delta > timedelta(2):
-        #    logger.warning("Waiting for log compression worker took more than 2 seconds")
+        # if delta > timedelta(2):
+        #     logger.warning("Waiting for log compression worker took more than 2 seconds")
         self.compressor = None
 
+    def _log_files(self):
+        log_dir = os.path.dirname(self.baseFilename)
+
+        def log_info(m):
+            idx = int(m.group(1)) if m.group(1) is not None else 0
+            return os.path.join(log_dir, m.group(0)), idx
+
+        matches = (self.log_pattern.match(name) for name in os.listdir(log_dir))
+        return (log_info(m) for m in matches if m is not None)
+
     @staticmethod
-    def _file_compression(file_name):
-        if file_name.endswith(".gz"): return "gz"
-        if file_name.endswith(".xz"): return "xz"
+    def _file_compression(filename):
+        if filename.endswith(".gz"): return "gz"
+        if filename.endswith(".xz"): return "xz"
         return None
 
     @staticmethod
-    def _open_log(file_name, mode):
-        compression = TimeAndSizeRotatingFileHandler._file_compression(file_name)
-        if compression == "gz": return gzip.open(file_name, mode)
-        if compression == "xz": return lzma.open(file_name, mode)
-        return open(file_name, mode)
+    def _file_update_compression(filename, compression):
+        if filename.endswith(".gz") or filename.endswith(".xz"):
+            filename = filename[:-3]
+        if compression is None:
+            return filename
+        return "{}.{}".format(filename, compression)
+
+    @staticmethod
+    def _open_log(filename, mode):
+        compression = TimeAndSizeRotatingFileHandler._file_compression(filename)
+        if compression == "gz": return gzip.open(filename, mode)
+        if compression == "xz": return lzma.open(filename, mode)
+        return open(filename, mode)
 
     @staticmethod
     def _recompress(source, dest):
@@ -97,50 +110,21 @@ class TimeAndSizeRotatingFileHandler(TimedRotatingFileHandler, RotatingFileHandl
             f_out.write(f_in.read())
         os.remove(source)
 
-    @staticmethod
-    def _file_index(file_name):
-        split = file_name.split(".")
-        index = split[-1]
-        if index in ["gz", "xz"]:
-            index = split[-2]
-        try:
-            return int(index)
-        except ValueError:
-            return 0
-
     def getFilesToDelete(self):
-        """
-        Determine the files to delete when rolling over.
+        log_files = [(name, idx) for name, idx in self._log_files()]
+        if len(log_files) == 0:
+            return []
 
-        Note: This is copied from `TimedRotatingFileHandler`. The reason for
-        copying is to allow sorting in a custom way (by modified time).
-        Also minor optimisation to sort only when needed (>self.backupCount)
-        """
-        dirName, baseName = os.path.split(self.baseFilename)
-        fileNames = os.listdir(dirName)
-        result = []
-        prefix = baseName + "."
-        plen = len(prefix)
-        for fileName in fileNames:
-            if fileName[:plen] == prefix:
-                suffix = fileName[plen:]
-                if suffix.endswith(".gz"):
-                    suffix = suffix[:-3]
-                if suffix.endswith(".xz"):
-                    suffix = suffix[:-3]
-                if self.extMatch.match(suffix):
-                    result.append(os.path.join(dirName, fileName))
-        if len(result) <= self.backupCount:
-            result = []
-        else:
-            self._sort_for_removal(result)
-            result = result[:len(result) - self.backupCount]
-        return result
+        log_files, log_indexes = zip(*log_files)
+        keep_count = self.backupCount
 
-    @staticmethod
-    def _sort_for_removal(result):
-        """
-        Sort files in the order they should be removed.
-        Currently using last modification time but this method can be overridden
-        """
-        result.sort(key=os.path.getmtime)
+        # This can happen when compression is still in progress
+        if max(log_indexes) < self.max_index:
+            keep_count -= 1
+
+        if len(log_files) <= keep_count:
+            return []
+
+        log_files = list(log_files)
+        log_files.sort(key=os.path.getmtime)
+        return log_files[:-keep_count]

--- a/stp_core/config.py
+++ b/stp_core/config.py
@@ -7,8 +7,6 @@ import logging
 baseDir = os.getcwd()
 
 # Log configuration
-logRotationWhen = 'W6'
-logRotationInterval = 1
 logRotationBackupCount = 300
 logRotationMaxBytes = 100 * 1024 * 1024
 logRotationCompression = "xz"

--- a/stp_core/config.py
+++ b/stp_core/config.py
@@ -9,9 +9,9 @@ baseDir = os.getcwd()
 # Log configuration
 logRotationWhen = 'W6'
 logRotationInterval = 1
-logRotationBackupCount = 50
+logRotationBackupCount = 300
 logRotationMaxBytes = 100 * 1024 * 1024
-logRotationCompress = True
+logRotationCompression = "xz"
 logFormat = '{asctime:s} | {levelname:8s} | {filename:20s} ({lineno:d}) | {funcName:s} | {message:s}'
 logFormatStyle = '{'
 


### PR DESCRIPTION
- Added xz compression option
- Moved compression to separate process
- Removed rotation date from log filenames
- Removed time rotation logic