### PR TITLE
[RUN_CMD] Catch stderr if external cmd flush error into stderr (jouralctl inside docker containers for example)

### DIFF
--- a/plenum/server/validator_info_tool.py
+++ b/plenum/server/validator_info_tool.py
@@ -492,6 +492,7 @@ class ValidatorNodeInfoTool:
                              shell=True,
                              universal_newlines=True,
                              stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,
                              timeout=5)
         return ret.stdout
 


### PR DESCRIPTION


Signed-off-by: Andrew Nikitin <andrew.nikitin@dsr-corporation.com>