### PR TITLE
INDY-1363: add unsigned and signed action to ActionReqHandler

### DIFF
--- a/plenum/server/action_req_handler.py
+++ b/plenum/server/action_req_handler.py
@@ -6,6 +6,9 @@ class ActionReqHandler(RequestHandler):
     def __init__(self):
         super().__init__()
 
+    unsigned_action_types = set()
+    signed_action_types = set()
+
     def doStaticValidation(self, request: Request):
         pass
 
@@ -14,3 +17,4 @@ class ActionReqHandler(RequestHandler):
 
     def apply(self, req: Request, cons_time: int):
         pass
+

--- a/plenum/server/action_req_handler.py
+++ b/plenum/server/action_req_handler.py
@@ -17,4 +17,3 @@ class ActionReqHandler(RequestHandler):
 
     def apply(self, req: Request, cons_time: int):
         pass
-

--- a/plenum/server/client_authn.py
+++ b/plenum/server/client_authn.py
@@ -181,6 +181,7 @@ class CoreAuthMixin:
         DomainRequestHandler.query_types
     )
     action_types = ActionReqHandler.operation_types
+    signed_action = ActionReqHandler.signed_action_types
 
     def is_query(self, typ):
         return typ in self.query_types
@@ -191,6 +192,10 @@ class CoreAuthMixin:
     @classmethod
     def is_action(cls, typ):
         return typ in cls.action_types
+
+    @classmethod
+    def is_signed_action(cls, typ):
+        return typ in cls.signed_action
 
     @staticmethod
     def _extract_signature(msg):

--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -2086,9 +2086,6 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
     def is_action(self, txn_type) -> bool:
         return txn_type in self.actionReqHandler.operation_types
 
-    def is_unsigned_action(self, txn_type) -> bool:
-        return txn_type in self.actionReqHandler.unsigned_action
-
     def process_query(self, request: Request, frm: str):
         # Process a read request from client
         handler = self.get_req_handler(txn_type=request.operation[TXN_TYPE])

--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -2086,6 +2086,9 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
     def is_action(self, txn_type) -> bool:
         return txn_type in self.actionReqHandler.operation_types
 
+    def is_unsigned_action(self, txn_type) -> bool:
+        return txn_type in self.actionReqHandler.unsigned_action
+
     def process_query(self, request: Request, frm: str):
         # Process a read request from client
         handler = self.get_req_handler(txn_type=request.operation[TXN_TYPE])

--- a/plenum/server/req_authenticator.py
+++ b/plenum/server/req_authenticator.py
@@ -30,7 +30,8 @@ class ReqAuthenticator:
         identifiers = set()
         typ = req_data.get(OPERATION, {}).get(TXN_TYPE)
         for authenticator in self._authenticators:
-            if authenticator.is_query(typ):
+            if authenticator.is_query(typ) or \
+                    not authenticator.is_signed_action(typ):
                 return set()
             if not (authenticator.is_write(typ) or
                     authenticator.is_action(typ)):


### PR DESCRIPTION
Previously, the sending of the validator info command could only be signed. Now this feature is eliminated.

Changes:
- added unsigned_action_types and signed_action_types to ActionReqHandler
- added check to signed action in CoreAuthMixin
