### PR TITLE
Added support for Python 3.6 (3.6 and up uses Python's hashlib for sh…

### DIFF
--- a/state/util/utils.py
+++ b/state/util/utils.py
@@ -1,11 +1,15 @@
 import os
 import string
 
-import sha3 as _sha3
-
-
-def sha3_256(x):
-    return _sha3.sha3_256(x).digest()
+# Python 3.6 introduces support for sha3_256 encryption through its own hashlib library. 3.6 also breaks
+# the sha3 external dependency, so use hashlib for Python 3.6 and up.
+try:
+     # For python 3.6+
+     from hashlib import sha3_256              # sha3_256 requires bytes
+except ImportError:
+     # For python 3.5
+     import sha3
+     sha3_256 = lambda x: sha3.sha3_256(x.decode())   # _sha3.sha3_256 requires a string
 
 
 import rlp

--- a/state/util/utils.py
+++ b/state/util/utils.py
@@ -5,11 +5,10 @@ import string
 # the sha3 external dependency, so use hashlib for Python 3.6 and up.
 try:
      # For python 3.6+
-     from hashlib import sha3_256              # sha3_256 requires bytes
+     from hashlib import sha3_256  # sha3_256 requires bytes
 except ImportError:
      # For python 3.5
      import sha3
-     sha3_256 = lambda x: sha3.sha3_256(x.decode())   # _sha3.sha3_256 requires a string
 
 
 import rlp
@@ -134,7 +133,10 @@ def int_to_32bytearray(i):
 
 
 def sha3(seed):
-    return sha3_256(to_string(seed))
+    try:
+        return sha3_256(to_string(seed))
+    except:
+        return sha3.sha3_256(to_string(seed)).digest()
 
 
 # assert encode_hex(sha3(b'')) == b'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'

--- a/state/util/utils.py
+++ b/state/util/utils.py
@@ -8,8 +8,11 @@ try:
      from hashlib import sha3_256  # sha3_256 requires bytes
 except ImportError:
      # For python 3.5
-     import sha3
+    import sha3 as _sha3 # renamed to _sha3 to avoid a naming conflict
 
+    # should be equivalent to hashlib.sha3_256(x)
+    def sha3_256(x):
+        return _sha3.sha3_256(x).digest()
 
 import rlp
 from rlp.sedes import big_endian_int, BigEndianInt, Binary
@@ -133,10 +136,7 @@ def int_to_32bytearray(i):
 
 
 def sha3(seed):
-    try:
-        return sha3_256(to_string(seed))
-    except:
-        return sha3.sha3_256(to_string(seed)).digest()
+    return sha3_256(to_string(seed))
 
 
 # assert encode_hex(sha3(b'')) == b'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'


### PR DESCRIPTION
Added support for Python 3.6 (3.6 and up uses Python's hashlib for sha3_256 instead of sha3, which breaks in 3.6)
    
    Signed-off-by: ryanwest6 <31378238+ryanwest6@users.noreply.github.com>