### PR TITLE
INDY-1404: Do not start View Change until Catchup is finished

### DIFF
--- a/plenum/common/ledger_manager.py
+++ b/plenum/common/ledger_manager.py
@@ -877,8 +877,6 @@ class LedgerManager(HasActionQueue):
                          .format(self, ledger_id))
 
     def catchup_ledger(self, ledger_id, request_ledger_statuses=True):
-        # if self.owner.name == 'Theta':
-        #     print("BBBB")
         try:
             ledger_info = self.getLedgerInfoByType(ledger_id)
             ledger_info.set_defaults()

--- a/plenum/common/ledger_manager.py
+++ b/plenum/common/ledger_manager.py
@@ -877,6 +877,8 @@ class LedgerManager(HasActionQueue):
                          .format(self, ledger_id))
 
     def catchup_ledger(self, ledger_id, request_ledger_statuses=True):
+        # if self.owner.name == 'Theta':
+        #     print("BBBB")
         try:
             ledger_info = self.getLedgerInfoByType(ledger_id)
             ledger_info.set_defaults()

--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -1507,7 +1507,6 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
             if isinstance(msg, ViewChangeDone):
                 future_vcd_msg = FutureViewChangeDone(vcd_msg=msg, from_current_state=from_current_state)
                 self.msgsToViewChanger.append((future_vcd_msg, frm))
-                # self.view_changer.process_future_view_vchd_msg(future_vcd_msg, frm)
         else:
             return True
         return False

--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -105,7 +105,7 @@ from plenum.server.req_handler import RequestHandler
 from plenum.server.router import Router
 from plenum.server.suspicion_codes import Suspicions
 from plenum.server.validator_info_tool import ValidatorNodeInfoTool
-from plenum.server.view_change.view_changer import ViewChanger
+from plenum.server.view_change.view_changer import ViewChanger, FutureViewChangeDone
 
 pluginManager = PluginManager()
 logger = getlogger()
@@ -1499,8 +1499,9 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
                         format(self, msg))
             self.msgsForFutureViews[view_no].append((msg, frm))
             if isinstance(msg, ViewChangeDone):
-                # TODO this is put of the msgs queue scope
-                self.view_changer.on_future_view_vchd_msg(view_no, frm, from_current_state=from_current_state)
+                future_vcd_msg = FutureViewChangeDone(vcd_msg=msg, from_current_state=from_current_state)
+                self.msgsToViewChanger.append((future_vcd_msg, frm))
+                # self.view_changer.process_future_view_vchd_msg(future_vcd_msg, frm)
         else:
             return True
         return False

--- a/plenum/server/view_change/view_changer.py
+++ b/plenum/server/view_change/view_changer.py
@@ -420,6 +420,7 @@ class ViewChanger(HasActionQueue, MessageProcessor):
         :param limit: the maximum number of messages to service
         :return: the number of messages successfully processed
         """
+        # do not start any view changes until catch-up is finished!
         if self.node.mode == Mode.syncing:
             return 0
         return await self.inBoxRouter.handleAll(self.inBox, limit)

--- a/plenum/server/view_change/view_changer.py
+++ b/plenum/server/view_change/view_changer.py
@@ -305,12 +305,9 @@ class ViewChanger(HasActionQueue, MessageProcessor):
         view_no = future_vcd_msg.vcd_msg.viewNo
         if not ((view_no > self.view_no) or
                 (self.view_no == 0 and from_current_state)):
-            raise PlenumValueError(
-                'view_no', view_no,
-                ("= 0 or > {}" if from_current_state
-                 else "> {}").format(self.view_no),
-                prefix=self
-            )
+            # it means we already processed this future View Change Done
+            return
+
         if view_no not in self._next_view_indications:
             self._next_view_indications[view_no] = set()
         self._next_view_indications[view_no].add(frm)

--- a/plenum/test/view_change/helper.py
+++ b/plenum/test/view_change/helper.py
@@ -89,6 +89,23 @@ def ensure_view_change(looper, nodes, exclude_from_check=None,
     """
     old_view_no = checkViewNoForNodes(nodes)
 
+    old_meths = do_view_change(nodes)
+
+    perf_check_freq = next(iter(nodes)).config.PerfCheckFreq
+    timeout = custom_timeout or waits.expectedPoolViewChangeStartedTimeout(
+        len(nodes)) + perf_check_freq
+    nodes_to_check = nodes if exclude_from_check is None else [
+        n for n in nodes if n not in exclude_from_check]
+    logger.debug('Checking view no for nodes {}'.format(nodes_to_check))
+    looper.run(eventually(checkViewNoForNodes, nodes_to_check, old_view_no + 1,
+                          retryWait=1, timeout=timeout))
+
+    revert_do_view_change(nodes, old_meths)
+
+    return old_view_no + 1
+
+
+def do_view_change(nodes):
     old_meths = {node.name: {} for node in nodes}
     view_changes = {}
     for node in nodes:
@@ -107,21 +124,14 @@ def ensure_view_change(looper, nodes, exclude_from_check=None,
             slow_master, node.monitor)
         node._update_new_ordered_reqs_count = types.MethodType(
             lambda self: True, node)
+    return old_meths
 
-    perf_check_freq = next(iter(nodes)).config.PerfCheckFreq
-    timeout = custom_timeout or waits.expectedPoolViewChangeStartedTimeout(
-        len(nodes)) + perf_check_freq
-    nodes_to_check = nodes if exclude_from_check is None else [
-        n for n in nodes if n not in exclude_from_check]
-    logger.debug('Checking view no for nodes {}'.format(nodes_to_check))
-    looper.run(eventually(checkViewNoForNodes, nodes_to_check, old_view_no + 1,
-                          retryWait=1, timeout=timeout))
 
+def revert_do_view_change(nodes, old_meths):
     logger.debug('Patching back perf check for all nodes')
     for node in nodes:
         node.monitor.isMasterDegraded = old_meths[node.name]['isMasterDegraded']
         node._update_new_ordered_reqs_count = old_meths[node.name]['_update_new_ordered_reqs_count']
-    return old_view_no + 1
 
 
 def ensure_several_view_change(looper, nodes, vc_count=1,

--- a/plenum/test/view_change/test_api.py
+++ b/plenum/test/view_change/test_api.py
@@ -1,10 +1,8 @@
 import pytest
 
-from common.exceptions import PlenumValueError
-from plenum.common.messages.node_messages import ViewChangeDone
-from plenum.server.view_change.view_changer import ViewChanger, FutureViewChangeDone
-from plenum.test.testing_utils import FakeSomething
 from plenum.server.quorums import Quorums
+from plenum.server.view_change.view_changer import ViewChanger
+from plenum.test.testing_utils import FakeSomething
 
 
 @pytest.fixture(scope='module')
@@ -21,21 +19,3 @@ def view_changer():
     )
     view_changer = ViewChanger(node)
     return view_changer
-
-
-def test_on_future_view_vchd_msg(view_changer):
-    view_no = 0
-
-    assert view_no == view_changer.view_no
-    with pytest.raises(PlenumValueError) as excinfo:
-        view_changer.process_future_view_vchd_msg(
-            FutureViewChangeDone(ViewChangeDone(view_no, "Node1", []), False), "Node1")
-    assert ("expected: > {}"
-            .format(view_changer.view_no)) in str(excinfo.value)
-
-    view_changer.view_no = 1
-    with pytest.raises(PlenumValueError) as excinfo:
-        view_changer.process_future_view_vchd_msg(
-            FutureViewChangeDone(ViewChangeDone(view_no, "Node1", []), True), "Node1")
-    assert ("expected: = 0 or > {}"
-            .format(view_changer.view_no)) in str(excinfo.value)

--- a/plenum/test/view_change/test_api.py
+++ b/plenum/test/view_change/test_api.py
@@ -1,7 +1,8 @@
 import pytest
 
 from common.exceptions import PlenumValueError
-from plenum.server.view_change.view_changer import ViewChanger
+from plenum.common.messages.node_messages import ViewChangeDone
+from plenum.server.view_change.view_changer import ViewChanger, FutureViewChangeDone
 from plenum.test.testing_utils import FakeSomething
 from plenum.server.quorums import Quorums
 
@@ -27,12 +28,14 @@ def test_on_future_view_vchd_msg(view_changer):
 
     assert view_no == view_changer.view_no
     with pytest.raises(PlenumValueError) as excinfo:
-        view_changer.on_future_view_vchd_msg(view_no, "Node1", False)
+        view_changer.process_future_view_vchd_msg(
+            FutureViewChangeDone(ViewChangeDone(view_no, "Node1", []), False), "Node1")
     assert ("expected: > {}"
             .format(view_changer.view_no)) in str(excinfo.value)
 
     view_changer.view_no = 1
     with pytest.raises(PlenumValueError) as excinfo:
-        view_changer.on_future_view_vchd_msg(view_no,  "Node1", True)
+        view_changer.process_future_view_vchd_msg(
+            FutureViewChangeDone(ViewChangeDone(view_no, "Node1", []), True), "Node1")
     assert ("expected: = 0 or > {}"
             .format(view_changer.view_no)) in str(excinfo.value)

--- a/plenum/test/view_change/test_new_node_joins_after_view_change.py
+++ b/plenum/test/view_change/test_new_node_joins_after_view_change.py
@@ -83,7 +83,7 @@ def test_old_non_primary_restart_after_view_change(new_node_in_correct_view,
                                         tdir, allPluginsPath)
     txnPoolNodeSet = remaining_nodes + [restarted_node]
     looper.run(eventually(checkViewNoForNodes,
-                          txnPoolNodeSet, old_view_no + 1, timeout=10))
+                          txnPoolNodeSet, old_view_no + 1, timeout=30))
     assert len(getAllReturnVals(restarted_node.view_changer,
                                 restarted_node.view_changer._start_view_change_if_possible,
                                 compare_val_to=True)) > 0

--- a/plenum/test/view_change/test_no_view_change_while_catchup.py
+++ b/plenum/test/view_change/test_no_view_change_while_catchup.py
@@ -1,0 +1,41 @@
+from plenum.common.startable import Mode
+from plenum.test.delayers import icDelay
+from plenum.test.helper import checkViewNoForNodes, waitForViewChange
+from plenum.test.stasher import delay_rules
+from plenum.test.view_change.helper import do_view_change, revert_do_view_change, ensure_view_change
+
+
+def test_no_view_change_while_syncing(txnPoolNodeSet, looper):
+    for node in txnPoolNodeSet:
+        node.mode = Mode.syncing
+
+    old_view_no = checkViewNoForNodes(txnPoolNodeSet)
+    old_meths = do_view_change(txnPoolNodeSet)
+    for node in txnPoolNodeSet:
+        node.view_changer.sendInstanceChange(old_view_no + 1)
+    looper.runFor(5)
+    new_view_no = checkViewNoForNodes(txnPoolNodeSet)
+
+    assert old_view_no == new_view_no
+
+    revert_do_view_change(txnPoolNodeSet, old_meths)
+    for node in txnPoolNodeSet:
+        node.mode = Mode.participating
+
+    waitForViewChange(looper, txnPoolNodeSet, expectedViewNo=old_view_no + 1)
+
+
+def test_no_propagated_future_view_change_while_syncing(txnPoolNodeSet, looper):
+    lagged_node = txnPoolNodeSet[-1]
+    other_nodes = txnPoolNodeSet[:-1]
+    lagged_node.mode = Mode.syncing
+    old_view_no = checkViewNoForNodes([lagged_node])
+
+    with delay_rules(lagged_node.nodeIbStasher, icDelay()):
+        ensure_view_change(looper, other_nodes)
+        looper.runFor(5)
+        assert old_view_no == checkViewNoForNodes([lagged_node])
+
+        lagged_node.mode = Mode.participating
+        waitForViewChange(looper, [lagged_node], expectedViewNo=old_view_no + 1,
+                          customTimeout=10)

--- a/plenum/test/view_change/test_view_change_after_back_to_quorum_with_disconnected_primary.py
+++ b/plenum/test/view_change/test_view_change_after_back_to_quorum_with_disconnected_primary.py
@@ -1,14 +1,23 @@
-from plenum.server.view_change.view_changer import ViewChanger
-from plenum.test.pool_transactions.helper import disconnect_node_and_ensure_disconnected
-from plenum.test.view_change.helper import start_stopped_node, ensure_view_change_by_primary_restart
+import pytest
 
-from plenum.test.test_node import get_master_primary_node
+from plenum.server.view_change.view_changer import ViewChanger
 from plenum.test.helper import checkViewNoForNodes, waitForViewChange, sdk_send_random_and_check
 from plenum.test.node_catchup.helper import ensure_all_nodes_have_same_data
+from plenum.test.pool_transactions.helper import disconnect_node_and_ensure_disconnected
+from plenum.test.test_node import get_master_primary_node
+from plenum.test.view_change.helper import start_stopped_node, ensure_view_change_by_primary_restart
 
 # We do 2 view changes during this test. Timeout for one view change is 60 sec.
 # Test running time will be expected near 2 * 60 = 120, so let's define it as 150 sec.
 TestRunningTimeLimitSec = 150
+
+
+@pytest.fixture(scope="module", autouse=True)
+def tconf(tconf):
+    old_vc_timeout = tconf.VIEW_CHANGE_TIMEOUT
+    tconf.VIEW_CHANGE_TIMEOUT = 10
+    yield tconf
+    tconf.VIEW_CHANGE_TIMEOUT = old_vc_timeout
 
 
 def test_view_change_after_back_to_quorum_with_disconnected_primary(txnPoolNodeSet, looper,

--- a/plenum/test/view_change/test_view_change_after_back_to_quorum_with_disconnected_primary.py
+++ b/plenum/test/view_change/test_view_change_after_back_to_quorum_with_disconnected_primary.py
@@ -1,5 +1,3 @@
-import pytest
-
 from plenum.server.view_change.view_changer import ViewChanger
 from plenum.test.helper import checkViewNoForNodes, waitForViewChange, sdk_send_random_and_check
 from plenum.test.node_catchup.helper import ensure_all_nodes_have_same_data
@@ -10,14 +8,6 @@ from plenum.test.view_change.helper import start_stopped_node, ensure_view_chang
 # We do 2 view changes during this test. Timeout for one view change is 60 sec.
 # Test running time will be expected near 2 * 60 = 120, so let's define it as 150 sec.
 TestRunningTimeLimitSec = 150
-
-
-@pytest.fixture(scope="module", autouse=True)
-def tconf(tconf):
-    old_vc_timeout = tconf.VIEW_CHANGE_TIMEOUT
-    tconf.VIEW_CHANGE_TIMEOUT = 10
-    yield tconf
-    tconf.VIEW_CHANGE_TIMEOUT = old_vc_timeout
 
 
 def test_view_change_after_back_to_quorum_with_disconnected_primary(txnPoolNodeSet, looper,


### PR DESCRIPTION
- do not process any View Change related messages (including ViewChangeDone from Current State for primary propagation) until the current catchup is finished;
- this fixes initialization of a node where we mixed together initial catchup and primary propagation (initial view change);
- also fixed recovering when primary is disconnected and (n-f)th node joins the pool