### PR TITLE
[INDY-1435] Throughput calculating fixes

### DIFF
--- a/plenum/config.py
+++ b/plenum/config.py
@@ -136,6 +136,14 @@ DashboardUpdateFreq = 5
 ThroughputGraphDuration = 240
 LatencyWindowSize = 30
 LatencyGraphDuration = 240
+
+# Two following parameter is define collecting statistic timeout for
+# collecting ordered request and throughput evaluating them.
+# In other words, during ThroughputInnerWindowSize * ThroughputThresholdWindowCount seconds,
+# throughput will returned as None for corresponding getThroughput methods.
+ThroughputInnerWindowSize = 15
+ThroughputThresholdWindowCount = 16
+
 notifierEventTriggeringConfig = {
     'clusterThroughputSpike': {
         'bounds_coeff': 10,

--- a/plenum/test/monitoring/test_monitoring_params_with_zfn.py
+++ b/plenum/test/monitoring/test_monitoring_params_with_zfn.py
@@ -4,8 +4,20 @@ from plenum.test.helper import get_key_from_req
 
 nodeCount = 7
 
+@pytest.fixture(scope="module")
+def tconf(tconf):
+    old_thr_window_size = tconf.ThroughputInnerWindowSize
+    old_thr_window_count = tconf.ThroughputThresholdWindowCount
+    tconf.ThroughputInnerWindowSize = 5
+    tconf.ThroughputThresholdWindowCount = 2
+
+    yield tconf
+    tconf.ThroughputInnerWindowSize = old_thr_window_size
+    tconf.ThroughputThresholdWindowCount = old_thr_window_count
+
 
 def testThroughputThreshold(looper, txnPoolNodeSet, requests):
+    looper.runFor(10)
     for node in txnPoolNodeSet:
         masterThroughput, avgBackupThroughput = node.monitor.getThroughputs(
             node.instances.masterId)

--- a/plenum/test/monitoring/test_request_measurement_class.py
+++ b/plenum/test/monitoring/test_request_measurement_class.py
@@ -1,0 +1,118 @@
+import pytest
+from plenum.server.monitor import RequestMeasurement
+
+
+ACCURACY = .1e-5
+
+
+@pytest.fixture(scope="function")
+def request_measurement():
+    rm = RequestMeasurement()
+    rm.first_ts = 1
+    rm.window_start_ts = 1
+    return rm
+
+
+def test_add_request(request_measurement):
+    assert request_measurement.add_request
+
+
+@pytest.mark.skip(reason="Not implemented yet")
+def test_get_avg_latency(request_measurement):
+    assert request_measurement.get_avg_latency
+
+
+@pytest.mark.skip(reason="Not implemented yet")
+def test_get_max_latency(request_measurement):
+    assert request_measurement.get_max_latency
+
+
+def test_get_throughput(request_measurement):
+    assert request_measurement.get_throughput
+
+
+@pytest.mark.skip(reason="Not implemented yet")
+def test_avg_latency(rm_with_random_requests, recv_ordered_ts):
+    assert abs(rm_with_random_requests.get_avg_latency() - sum([b - a for a, b in recv_ordered_ts]) / len(recv_ordered_ts)) < ACCURACY
+
+
+@pytest.mark.skip(reason="Not implemented yet")
+def test_max_latency(rm_with_random_requests, recv_ordered_ts):
+    assert rm_with_random_requests.get_max_latency() == max([b - a for a, b in recv_ordered_ts])
+
+
+def test_add_request_and_eval_first_throughput(request_measurement):
+    rm = request_measurement
+    ordered_ts = [x for x in range(1, rm.inner_window + 2)]
+    assert len(ordered_ts) == rm.inner_window + 1
+    for ts in ordered_ts:
+        request_measurement.add_request(ordered_ts=ts)
+    assert rm.throughput != 0
+    assert rm.window_start_ts == rm.first_ts + rm.inner_window
+
+
+def test_get_thoughput_ts_less_than_window(request_measurement):
+    rm = request_measurement
+    ordered_ts = [1, 2, 3, 5, rm.min_cnt * rm.inner_window]
+    for ts in ordered_ts:
+        rm.add_request(ordered_ts=ts)
+    assert rm.get_throughput(rm.min_cnt * rm.inner_window) is None
+
+
+def test_get_throughput_out_of_first_window(request_measurement):
+    rm = request_measurement
+    for ts in [1, 2, 3, rm.window_start_ts + rm.inner_window + 1]:
+        rm.add_request(ordered_ts=ts)
+    assert rm.window_start_ts == rm.first_ts + rm.inner_window
+    assert rm.reqs_in_window == 1
+
+
+def test_get_throughput_meaning_avg_accuracy(request_measurement):
+    """
+    Add 10 * min_cnt * inner_window = 2400 of consistent timestamps.
+    Asymptotically, throughput in that case must be around 1 (2400 ordered for 2400 seconds)
+    """
+    rm = request_measurement
+    request_ts = 10 * rm.min_cnt * rm.inner_window
+    for ts in range(1, request_ts + 1):
+        rm.add_request(ordered_ts=ts)
+    throughput = rm.get_throughput(request_ts)
+    assert abs(throughput - 1) < ACCURACY
+
+
+def test_get_throughput_return_not_none_if_greater_that_threshold(request_measurement):
+    rm = request_measurement
+    ordered_ts = [1, 2, 3, 5, 240, 240, 240, rm.min_cnt * rm.inner_window]
+    for ts in ordered_ts:
+        rm.add_request(ordered_ts=ts)
+    assert rm.get_throughput(rm.min_cnt * rm.inner_window + 1) > 0
+
+
+def test_get_throughput_return_if_ts_only_for_first_window(request_measurement):
+    rm = request_measurement
+    ordered_ts = [x for x in range(1, rm.inner_window)]
+    for ts in ordered_ts:
+        rm.add_request(ordered_ts=ts)
+    # All of timestamps are included into first window
+    assert rm.first_ts == rm.window_start_ts
+    assert rm.get_throughput(rm.min_cnt * rm.inner_window + 10) is not None
+
+
+def test_get_throughput_return_0_if_there_is_no_any_requested(request_measurement):
+    rm = request_measurement
+    assert rm.get_throughput() == 0
+
+
+def test_moving_window(request_measurement):
+    rm = request_measurement
+    ordered_ts = [x for x in range(rm.inner_window + 2)]
+    # Check, that last elem is out from first window
+    assert ordered_ts[-1] > rm.inner_window
+    for ts in ordered_ts:
+        rm.add_request(ordered_ts=ts)
+    # Check, that window was moved
+    assert rm.first_ts != rm.window_start_ts
+    # Check that now in new window we have exactly 1 ordered timestamp
+    assert rm.reqs_in_window == 1
+    # Check, that throughput for first window was calculated
+    assert rm.throughput > 0

--- a/plenum/test/monitoring/test_throughput.py
+++ b/plenum/test/monitoring/test_throughput.py
@@ -1,4 +1,7 @@
 from typing import Iterable
+
+import pytest
+
 from stp_core.common.log import getlogger
 from plenum.test.helper import sdk_send_random_and_check
 
@@ -7,6 +10,7 @@ logger = getlogger()
 
 
 # noinspection PyIncorrectDocstring
+@pytest.mark.skip(reason="Dublicated in testThroughputThreshold")
 def testThroughput(looper, txnPoolNodeSet, sdk_wallet_client, sdk_pool_handle):
     """
     Checking if the throughput is being set


### PR DESCRIPTION
Changes:
-  Added threshold window = ThroughputInnerWindowSize * ThroughputThresholdWindowCount seconds. For now, throughput will return not None value only after this threshold.
By default, ThroughputInnerWindowSize = 15 seconds, ThroughputThresholdWindowCount = 16. Therefore, resulted threshold by default is 240 seconds.
- Throughput value is calculating now by using exponential moving average with alpha = 2 / (n+1), where 'n' is ThroughputThresholdWindowCount. 