### PR TITLE
INDY-1464: fix Propagate request for ATTRIB txn

### DIFF
--- a/common/serializers/signing_serializer.py
+++ b/common/serializers/signing_serializer.py
@@ -69,7 +69,7 @@ class SigningSerializer:
             keys.sort()
             strs = []
             for k in keys:
-                onm = ".".join([objname, k]) if objname else k
+                onm = ".".join([str(objname), str(k)]) if objname else k
                 strs.append(
                     str(k) + ":" + self.serialize(obj[k], level + 1, onm, toBytes=False))
             res = "|".join(strs)

--- a/common/test/test_signing_serializer.py
+++ b/common/test/test_signing_serializer.py
@@ -1,0 +1,140 @@
+from collections import OrderedDict
+
+import pytest
+
+from common.serializers.serialization import serialize_msg_for_signing
+
+
+def test_serialize_int():
+    assert b"1" == serialize_msg_for_signing(1)
+
+
+def test_serialize_str():
+    assert b"aaa" == serialize_msg_for_signing("aaa")
+
+
+def test_serialize_none():
+    assert b"" == serialize_msg_for_signing(None)
+
+
+def test_serialize_simple_dict():
+    assert b"1:a|2:b" == serialize_msg_for_signing({1: 'a', 2: 'b'})
+    assert b"1:a|2:b" == serialize_msg_for_signing({"2": 'b', "1": 'a'})
+
+
+def test_serialize_array():
+    assert b"1,5,3,4,2" == serialize_msg_for_signing([1, 5, 3, 4, 2])
+
+
+def test_serialize_ordered_dict():
+    v1 = OrderedDict([('1', 'a'), ('2', 'b')])
+    v2 = OrderedDict([('2', 'b'), ('1', 'a')])
+    assert b"1:a|2:b" == serialize_msg_for_signing(v1)
+    assert b"1:a|2:b" == serialize_msg_for_signing(v2)
+
+
+def test_serialize_dict_with_array():
+    assert b"1:a|2:b|3:1,2:k" == serialize_msg_for_signing({1: 'a', 2: 'b', 3: [1, {2: 'k'}]})
+    assert b"1:a|2:b|3:1,2:k" == serialize_msg_for_signing({'1': 'a', '2': 'b', '3': ['1', {'2': 'k'}]})
+
+
+@pytest.mark.skip("An issue in Signing Serializer: https://jira.hyperledger.org/browse/INDY-1469")
+def test_serialize_dicts_with_different_keys():
+    v1 = serialize_msg_for_signing(
+        {
+            1: 'a',
+            2: {
+                3: 'b',
+                4: {
+                    5: {
+                        6: 'c'
+                    }
+                }
+            }
+        })
+    v2 = serialize_msg_for_signing(
+        {
+            1: 'a',
+            2: {
+                3: 'b',
+            },
+            4: {
+                5: {
+                    6: 'c'
+                }
+            }
+        })
+    assert v1 == v2
+
+
+@pytest.mark.skip("An issue in Signing Serializer: https://jira.hyperledger.org/browse/INDY-1469")
+def test_serialize_complex_dict():
+    assert b'1:a|2:3:b|2:4:5:6:c' == serialize_msg_for_signing(
+        {
+            1: 'a',
+            2: {
+                3: 'b',
+                4: {
+                    5: {
+                        6: 'c'
+                    }
+                }
+            }
+        })
+    assert b'1:a|2:3:b|2:4:5:6:c' == serialize_msg_for_signing(
+        {
+            '1': 'a',
+            '2': {
+                '3': 'b',
+                '4': {
+                    '5': {
+                        '6': 'c'
+                    }
+                }
+            }
+        })
+    v = serialize_msg_for_signing(
+        {
+            '1': 'a',
+            '2': 'b',
+            '3': {
+                '4': 'c',
+                '5': 'd',
+                '6': {
+                    '7': {
+                        '8': 'e',
+                        '9': 'f'
+                    },
+                    '10': {
+                        '11': 'g',
+                        '12': 'h'
+                    }
+                },
+                '13': {
+                    '13': {
+                        '13': 'i',
+                    }
+                }
+            }
+        })
+    assert b'1:a|2:b|3:4:c|3:5:d|3:6:7:8:e|3:6:7:9:f|3:6:10:11:g|3:6:10:12:h|3:13:13:13:i' == v
+
+
+@pytest.mark.skip("An issue in Signing Serializer: https://jira.hyperledger.org/browse/INDY-1469")
+def test_serialize_complex_ordered_dict():
+    assert b'1:a|2:3:b|4:c' == serialize_msg_for_signing(
+        OrderedDict([
+            ('1', 'a'),
+            ('2', OrderedDict([
+                ('3', 'b'),
+                ('4', 'c'),
+            ]))
+        ]))
+    assert b'1:a|2:3:b|4:c' == serialize_msg_for_signing(
+        OrderedDict([
+            ('2', OrderedDict([
+                ('4', 'c'),
+                ('3', 'b'),
+            ])),
+            ('1', 'a'),
+        ]))

--- a/plenum/common/txn_util.py
+++ b/plenum/common/txn_util.py
@@ -15,6 +15,10 @@ from stp_core.common.log import getlogger
 logger = getlogger()
 
 
+class TxnUtilConfig:
+    client_request_class = Request
+
+
 def getTxnOrderedFields():
     return OrderedDict([
         (f.IDENTIFIER.nm, (str, str)),
@@ -217,7 +221,7 @@ def reqToTxn(req):
             signatures=req.get(f.SIGS.nm, None),
             protocolVersion=req.get(f.PROTOCOL_VERSION.nm, None)
         )
-        req = Request(**kwargs)
+        req = TxnUtilConfig.client_request_class(**kwargs)
     if isinstance(req, Request):
         req_data = req.as_dict
         req_data[f.DIGEST.nm] = req.digest

--- a/plenum/server/message_handlers.py
+++ b/plenum/server/message_handlers.py
@@ -60,6 +60,8 @@ class BaseHandler(metaclass=ABCMeta):
             return None
 
         valid_msg = self.create(msg.msg, **params)
+        if valid_msg is None:
+            return None
         return self.processor(valid_msg, params, frm)
 
 

--- a/plenum/server/message_handlers.py
+++ b/plenum/server/message_handlers.py
@@ -4,7 +4,6 @@ from abc import ABCMeta, abstractmethod
 from plenum.common.constants import THREE_PC_PREFIX
 from plenum.common.messages.node_messages import MessageReq, MessageRep, \
     LedgerStatus, PrePrepare, ConsistencyProof, Propagate, Prepare, Commit
-from plenum.common.request import Request
 from plenum.common.types import f
 from plenum.server import replica
 from stp_core.common.log import getlogger
@@ -219,7 +218,7 @@ class PropagateHandler(BaseHandler):
 
     def create(self, msg: Dict, **kwargs) -> Propagate:
         ppg = Propagate(**msg)
-        request = Request(**ppg.request)
+        request = self.node._client_request_class(**ppg.request)
         if request.digest != kwargs[f.DIGEST.nm]:
             logger.debug(
                 '{} found PROPAGATE {} not '

--- a/plenum/server/message_handlers.py
+++ b/plenum/server/message_handlers.py
@@ -218,7 +218,7 @@ class PropagateHandler(BaseHandler):
 
     def create(self, msg: Dict, **kwargs) -> Propagate:
         ppg = Propagate(**msg)
-        request = self.node._client_request_class(**ppg.request)
+        request = self.node.client_request_class(**ppg.request)
         if request.digest != kwargs[f.DIGEST.nm]:
             logger.debug(
                 '{} found PROPAGATE {} not '

--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -119,7 +119,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
 
     suspicions = {s.code: s.reason for s in Suspicions.get_list()}
     keygenScript = "init_plenum_keys"
-    _client_request_class = SafeRequest
+    client_request_class = SafeRequest
     _info_tool_class = ValidatorNodeInfoTool
     # The order of ledger id in the following list determines the order in
     # which those ledgers will be synced. Think carefully before changing the
@@ -1715,7 +1715,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         needStaticValidation = False
         if all([msg.get(OPERATION), msg.get(f.REQ_ID.nm),
                 idr_from_req_data(msg)]):
-            cls = self._client_request_class
+            cls = self.client_request_class
             needStaticValidation = True
         elif OP_FIELD_NAME in msg:
             op = msg[OP_FIELD_NAME]
@@ -2212,7 +2212,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
                      format(self.name, msg))
 
         reqDict = msg.request
-        request = self._client_request_class(**reqDict)
+        request = self.client_request_class(**reqDict)
 
         clientName = msg.senderClient
 


### PR DESCRIPTION
- use correct Request class when processing requested PROPAGATE (since request class is overridden in indy-node)
- use correct Request class in 
- the tests are in `reqTotxn` (since request class is overridden in indy-node)
- fixed a small issue in SigningSerializer
- added tests for SigningSerializer (there is an issue there: INDY-1469)
- the tests for propagation of ATTRIB are in https://github.com/hyperledger/indy-node/pull/816

Signed-off-by: ashcherbakov <alexander.sherbakov@dsr-company.com>