### PR TITLE
INDY-1545: stop processing checkpoints in view change

### DIFF
--- a/plenum/server/replica.py
+++ b/plenum/server/replica.py
@@ -1889,9 +1889,8 @@ class Replica(HasActionQueue, MessageProcessor, HookManager):
         for k in previousCheckpoints:
             self.logger.trace("{} removing previous checkpoint {}".format(self, k))
             self.checkpoints.pop(k)
-        view_no = self.last_ordered_3pc[0]
-        self._remove_stashed_checkpoints(till_3pc_key=(view_no, seqNo))
-        self._gc((view_no, seqNo))
+        self._remove_stashed_checkpoints(till_3pc_key=(self.viewNo, seqNo))
+        self._gc((self.viewNo, seqNo))
         self.logger.info("{} marked stable checkpoint {}".format(self, (s, e)))
         self.processStashedMsgsForNewWaterMarks()
 

--- a/plenum/server/replica.py
+++ b/plenum/server/replica.py
@@ -1868,8 +1868,9 @@ class Replica(HasActionQueue, MessageProcessor, HookManager):
         for k in previousCheckpoints:
             self.logger.trace("{} removing previous checkpoint {}".format(self, k))
             self.checkpoints.pop(k)
-        self._remove_stashed_checkpoints(till_3pc_key=(self.viewNo, seqNo))
-        self._gc((self.viewNo, seqNo))
+        view_no = self.last_ordered_3pc[0]
+        self._remove_stashed_checkpoints(till_3pc_key=(view_no, seqNo))
+        self._gc((view_no, seqNo))
         self.logger.info("{} marked stable checkpoint {}".format(self, (s, e)))
         self.processStashedMsgsForNewWaterMarks()
 

--- a/plenum/server/replica.py
+++ b/plenum/server/replica.py
@@ -1751,7 +1751,7 @@ class Replica(HasActionQueue, MessageProcessor, HookManager):
         if self.isMaster:
             self.metrics.add_event(MetricsName.MASTER_ORDERED_BATCH_SIZE, pp.discarded)
 
-        self.addToCheckpoint(pp.ppSeqNo, pp.digest, pp.ledgerId)
+        self.addToCheckpoint(pp.ppSeqNo, pp.digest, pp.ledgerId, pp.viewNo)
 
         # BLS multi-sig:
         self._bls_bft_replica.process_order(key, self.quorums, pp)
@@ -1780,6 +1780,12 @@ class Replica(HasActionQueue, MessageProcessor, HookManager):
         seqNoEnd = msg.seqNoEnd
         if self.isPpSeqNoStable(seqNoEnd):
             self.discard(msg, reason="Checkpoint already stable", logMethod=self.logger.debug)
+            return True
+
+        if self.isPrimary is None and msg.viewNo < self.viewNo:
+            self.discard(msg,
+                         reason="Checkpoint from previous view",
+                         logMethod=self.logger.debug)
             return True
 
         seqNoStart = msg.seqNoStart
@@ -1830,7 +1836,7 @@ class Replica(HasActionQueue, MessageProcessor, HookManager):
                                 format(self, lag_in_checkpoints))
             self.node.start_catchup()
 
-    def addToCheckpoint(self, ppSeqNo, digest, ledger_id):
+    def addToCheckpoint(self, ppSeqNo, digest, ledger_id, view_no):
         for (s, e) in self.checkpoints.keys():
             if s <= ppSeqNo <= e:
                 state = self.checkpoints[s, e]  # type: CheckpointState
@@ -1858,11 +1864,11 @@ class Replica(HasActionQueue, MessageProcessor, HookManager):
                 self.checkpoints[s, e] = state
                 self.logger.info("{} sending Checkpoint {} view {} checkpointState digest {}. Ledger {} "
                                  "txn root hash {}. Committed state root hash {} Uncommitted state root hash {}".
-                                 format(self, (s, e), self.viewNo, state.digest, ledger_id,
+                                 format(self, (s, e), view_no, state.digest, ledger_id,
                                         self.txnRootHash(ledger_id), self.stateRootHash(ledger_id, committed=True),
                                         self.stateRootHash(ledger_id, committed=False)))
-                self.send(Checkpoint(self.instId, self.viewNo, s, e, state.digest))
-            self.processStashedCheckpoints((s, e))
+                self.send(Checkpoint(self.instId, view_no, s, e, state.digest))
+            self.processStashedCheckpoints((s, e), view_no)
 
     def markCheckPointStable(self, seqNo):
         previousCheckpoints = []
@@ -1930,16 +1936,16 @@ class Replica(HasActionQueue, MessageProcessor, HookManager):
                 end_pp_seq_numbers.append(seq_no_end)
         return sorted(end_pp_seq_numbers)
 
-    def processStashedCheckpoints(self, key):
+    def processStashedCheckpoints(self, key, view_no):
         # Remove all checkpoints from previous views if any
         self._remove_stashed_checkpoints(till_3pc_key=(self.viewNo, 0))
 
-        if key not in self.stashedRecvdCheckpoints.get(self.viewNo, {}):
+        if key not in self.stashedRecvdCheckpoints.get(view_no, {}):
             self.logger.trace("{} have no stashed checkpoints for {}")
-            return 0
+            return
 
         # Get a snapshot of all the senders of stashed checkpoints for `key`
-        senders = list(self.stashedRecvdCheckpoints[self.viewNo][key].keys())
+        senders = list(self.stashedRecvdCheckpoints[view_no][key].keys())
         total_processed = 0
         consumed = 0
 
@@ -1948,11 +1954,11 @@ class Replica(HasActionQueue, MessageProcessor, HookManager):
             # `stashedRecvdCheckpoints` because it might be removed from there
             # in case own checkpoint was stabilized when we were processing
             # stashed checkpoints from previous senders in this loop
-            if self.viewNo in self.stashedRecvdCheckpoints \
-                    and key in self.stashedRecvdCheckpoints[self.viewNo] \
-                    and sender in self.stashedRecvdCheckpoints[self.viewNo][key]:
+            if view_no in self.stashedRecvdCheckpoints \
+                    and key in self.stashedRecvdCheckpoints[view_no] \
+                    and sender in self.stashedRecvdCheckpoints[view_no][key]:
                 if self.processCheckpoint(
-                        self.stashedRecvdCheckpoints[self.viewNo][key].pop(sender),
+                        self.stashedRecvdCheckpoints[view_no][key].pop(sender),
                         sender):
                     consumed += 1
                 # Note that if `processCheckpoint` returned False then the
@@ -1962,12 +1968,12 @@ class Replica(HasActionQueue, MessageProcessor, HookManager):
 
         # If we have consumed stashed checkpoints for `key` from all the
         # senders then remove entries which have become empty
-        if self.viewNo in self.stashedRecvdCheckpoints \
-                and key in self.stashedRecvdCheckpoints[self.viewNo] \
-                and len(self.stashedRecvdCheckpoints[self.viewNo][key]) == 0:
-            del self.stashedRecvdCheckpoints[self.viewNo][key]
-            if len(self.stashedRecvdCheckpoints[self.viewNo]) == 0:
-                del self.stashedRecvdCheckpoints[self.viewNo]
+        if view_no in self.stashedRecvdCheckpoints \
+                and key in self.stashedRecvdCheckpoints[view_no] \
+                and len(self.stashedRecvdCheckpoints[view_no][key]) == 0:
+            del self.stashedRecvdCheckpoints[view_no][key]
+            if len(self.stashedRecvdCheckpoints[view_no]) == 0:
+                del self.stashedRecvdCheckpoints[view_no]
 
         restashed = total_processed - consumed
         self.logger.info('{} processed {} stashed checkpoints for {}, '

--- a/plenum/test/checkpoints/test_checkpoints_removal_in_view_change.py
+++ b/plenum/test/checkpoints/test_checkpoints_removal_in_view_change.py
@@ -1,0 +1,108 @@
+import pytest
+import sys
+
+from plenum.common.constants import CHECKPOINT, COMMIT, CONSISTENCY_PROOF
+from plenum.common.messages.node_messages import Checkpoint, CheckpointState
+from plenum.test.delayers import cDelay, chk_delay, cpDelay
+from plenum.test.helper import sdk_send_random_requests, \
+    sdk_get_and_check_replies, sdk_send_random_and_check
+from plenum.test.node_catchup.helper import ensure_all_nodes_have_same_data
+from plenum.test.stasher import delay_rules
+from plenum.test.test_node import getNonPrimaryReplicas, getAllReplicas, \
+    getPrimaryReplica, ensureElectionsDone
+from plenum.test.view_change.helper import ensure_view_change_complete
+from stp_core.loop.eventually import eventually
+
+CHK_FREQ = 2
+
+
+def delay_msg(nodes, delay_function):
+    for n in nodes:
+        n.nodeIbStasher.delay(delay_function(sys.maxsize))
+
+
+def reset_delay(nodes, message):
+    for n in nodes:
+        n.nodeIbStasher.reset_delays_and_process_delayeds(message)
+
+
+def test_checkpoints_removed_in_view_change(chkFreqPatched,
+                                            txnPoolNodeSet,
+                                            looper,
+                                            sdk_pool_handle,
+                                            sdk_wallet_client):
+    primary = txnPoolNodeSet[0]
+    slow_nodes = txnPoolNodeSet[:1]
+    correct_nodes = txnPoolNodeSet[1:3]
+    fast_nodes = txnPoolNodeSet[3:]
+    # sdk_send_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle,
+    #                           sdk_wallet_client, CHK_FREQ)
+    # for node in txnPoolNodeSet:
+    #     node.view_changer.on_master_degradation()
+    delay_msg(slow_nodes, chk_delay)
+    sdk_send_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle,
+                              sdk_wallet_client, CHK_FREQ)
+    ensure_all_nodes_have_same_data(looper, nodes=txnPoolNodeSet)
+    delay_msg(slow_nodes, cDelay)
+    delay_msg(correct_nodes, cDelay)
+
+    requests1 = sdk_send_random_requests(looper, sdk_pool_handle,
+                                         sdk_wallet_client, 1)
+    looper.run(eventually(last_prepared_certificate,
+                          slow_nodes,
+                          (0, CHK_FREQ + 1)))
+    looper.run(eventually(last_ordered_check,
+                          fast_nodes,
+                          (0, CHK_FREQ + 1)))
+    looper.run(eventually(checkpoint_finish,
+                          correct_nodes,
+                          1, CHK_FREQ))
+    delay_msg(txnPoolNodeSet, cpDelay)
+    # trigger view change on all nodes
+    for node in txnPoolNodeSet:
+        node.view_changer.on_master_degradation()
+    looper.run(eventually(check_view_no,
+                          slow_nodes,
+                          1))
+    # for node in txnPoolNodeSet:
+    #     node.viewNo += 1
+    #     node.view_changer.view_change_in_progress = True
+    reset_delay(slow_nodes, CHECKPOINT)
+    looper.run(eventually(checkpoint_finish,
+                          slow_nodes,
+                          1, CHK_FREQ))
+
+    reset_delay(slow_nodes, COMMIT)
+    reset_delay(correct_nodes, COMMIT)
+    sdk_get_and_check_replies(looper, requests1)
+    reset_delay(txnPoolNodeSet, CONSISTENCY_PROOF)
+    ensureElectionsDone(looper, txnPoolNodeSet)
+
+    sdk_send_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle,
+                              sdk_wallet_client, CHK_FREQ)
+    ensure_all_nodes_have_same_data(looper, nodes=txnPoolNodeSet)
+    # assert primary.master_last_ordered_3PC[1] == 2*CHK_FREQ + 1
+
+
+def last_prepared_certificate(nodes, num):
+    for n in nodes:
+        assert n.master_replica.last_prepared_certificate_in_view() == num
+
+
+def checkpoint_finish(nodes, start_pp_seq_no, end_pp_seq_no):
+    for n in nodes:
+        # assert n.master_replica.firstCheckPoint is not None
+        # assert n.master_replica.firstCheckPoint[0] == (start_pp_seq_no,
+        #                                                end_pp_seq_no)
+        for seq_no in range(start_pp_seq_no, end_pp_seq_no):
+            assert not (0, seq_no) in n.master_replica.sentPrePrepares
+
+
+def last_ordered_check(nodes, last_ordered):
+    for n in nodes:
+        assert n.master_last_ordered_3PC == last_ordered
+
+
+def check_view_no(nodes, view_no):
+    for n in nodes:
+        assert n.viewNo == view_no

--- a/plenum/test/checkpoints/test_checkpoints_removal_in_view_change.py
+++ b/plenum/test/checkpoints/test_checkpoints_removal_in_view_change.py
@@ -66,6 +66,8 @@ def test_checkpoints_removed_in_view_change(chkFreqPatched,
     for node in txnPoolNodeSet:
         node.viewNo -= 1
         node.view_changer.on_master_degradation()
+    for n in slow_nodes:
+        assert not n.master_replica.checkpoints[(1, CHK_FREQ)].isStable
     # Check ordering the last txn before catchup. Check client reply is enough
     # because slow_nodes contains 3 nodes and without their replies sdk method
     # for get reply will not successfully finish.

--- a/plenum/test/checkpoints/test_checkpoints_removal_in_view_change.py
+++ b/plenum/test/checkpoints/test_checkpoints_removal_in_view_change.py
@@ -103,14 +103,3 @@ def last_ordered_check(nodes, last_ordered, instance_id=None):
             if instance_id is None \
             else n.replicas[instance_id].last_ordered_3pc
         assert last_ordered_3pc == last_ordered
-
-
-def check_view_no(nodes, view_no):
-    for n in nodes:
-        assert n.viewNo == view_no
-
-
-def test_tmp(txnPoolNodeSet, looper):
-    for node in txnPoolNodeSet:
-        node.view_changer.on_master_degradation()
-        ensureElectionsDone(looper, txnPoolNodeSet)

--- a/plenum/test/checkpoints/test_checkpoints_removal_in_view_change.py
+++ b/plenum/test/checkpoints/test_checkpoints_removal_in_view_change.py
@@ -1,29 +1,15 @@
 import pytest
 import sys
 
-from plenum.common.constants import CHECKPOINT, COMMIT, CONSISTENCY_PROOF
-from plenum.common.messages.node_messages import Checkpoint, CheckpointState
-from plenum.test.delayers import cDelay, chk_delay, cpDelay
+from plenum.common.constants import CHECKPOINT, COMMIT
+from plenum.test.delayers import cDelay, chk_delay
 from plenum.test.helper import sdk_send_random_requests, \
     sdk_get_and_check_replies, sdk_send_random_and_check
 from plenum.test.node_catchup.helper import ensure_all_nodes_have_same_data
-from plenum.test.stasher import delay_rules
-from plenum.test.test_node import getNonPrimaryReplicas, getAllReplicas, \
-    getPrimaryReplica, ensureElectionsDone
-from plenum.test.view_change.helper import ensure_view_change_complete
+from plenum.test.test_node import ensureElectionsDone
 from stp_core.loop.eventually import eventually
 
 CHK_FREQ = 2
-
-
-def delay_msg(nodes, delay_function):
-    for n in nodes:
-        n.nodeIbStasher.delay(delay_function(sys.maxsize))
-
-
-def reset_delay(nodes, message):
-    for n in nodes:
-        n.nodeIbStasher.reset_delays_and_process_delayeds(message)
 
 
 def test_checkpoints_removed_in_view_change(chkFreqPatched,
@@ -31,57 +17,72 @@ def test_checkpoints_removed_in_view_change(chkFreqPatched,
                                             looper,
                                             sdk_pool_handle,
                                             sdk_wallet_client):
-    primary = txnPoolNodeSet[0]
-    slow_nodes = txnPoolNodeSet[:1]
-    correct_nodes = txnPoolNodeSet[1:3]
+    '''
+    Check that checkpoint finalize in view change before catchup doesn't clean
+    necessary data from requests and 3pc queues.
+    '''
+    slow_nodes = txnPoolNodeSet[:3]
     fast_nodes = txnPoolNodeSet[3:]
-    # sdk_send_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle,
-    #                           sdk_wallet_client, CHK_FREQ)
-    # for node in txnPoolNodeSet:
-    #     node.view_changer.on_master_degradation()
+    # delay checkpoints processing for slow_nodes
     delay_msg(slow_nodes, chk_delay)
+    # send txns for finalizing current checkpoint
     sdk_send_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle,
                               sdk_wallet_client, CHK_FREQ)
     ensure_all_nodes_have_same_data(looper, nodes=txnPoolNodeSet)
+    # delay commits processing for slow_nodes
     delay_msg(slow_nodes, cDelay)
-    delay_msg(correct_nodes, cDelay)
 
-    requests1 = sdk_send_random_requests(looper, sdk_pool_handle,
+    requests = sdk_send_random_requests(looper, sdk_pool_handle,
                                          sdk_wallet_client, 1)
+    # check that slow nodes have prepared certificate with new txn
     looper.run(eventually(last_prepared_certificate,
                           slow_nodes,
                           (0, CHK_FREQ + 1)))
+    # check that fast_nodes ordered new txn
     looper.run(eventually(last_ordered_check,
                           fast_nodes,
                           (0, CHK_FREQ + 1)))
-    looper.run(eventually(checkpoint_finish,
-                          correct_nodes,
+    # check that fast_nodes finalized first checkpoint
+    looper.run(eventually(check_checkpoint_finish,
+                          fast_nodes,
                           1, CHK_FREQ))
-    delay_msg(txnPoolNodeSet, cpDelay)
-    # trigger view change on all nodes
+    # View change start emulation for change viewNo
+    # and fix last prepare certificate
     for node in txnPoolNodeSet:
-        node.view_changer.on_master_degradation()
-    looper.run(eventually(check_view_no,
-                          slow_nodes,
-                          1))
-    # for node in txnPoolNodeSet:
-    #     node.viewNo += 1
-    #     node.view_changer.view_change_in_progress = True
+        node.viewNo += 1
+        node.master_replica.on_view_change_start()
+    # reset delay for checkpoints and check that slow_nodes finalized
+    # first checkpoint
     reset_delay(slow_nodes, CHECKPOINT)
-    looper.run(eventually(checkpoint_finish,
+    looper.run(eventually(check_checkpoint_finish,
                           slow_nodes,
                           1, CHK_FREQ))
-
+    # reset view change emulation and start real view change
+    for node in txnPoolNodeSet:
+        node.viewNo -= 1
+        node.view_changer.on_master_degradation()
+    # check ordering the last txn in catchup
     reset_delay(slow_nodes, COMMIT)
-    reset_delay(correct_nodes, COMMIT)
-    sdk_get_and_check_replies(looper, requests1)
-    reset_delay(txnPoolNodeSet, CONSISTENCY_PROOF)
+    sdk_get_and_check_replies(looper, requests)
+    # check view change finish
     ensureElectionsDone(looper, txnPoolNodeSet)
-
+    # check that all nodes have same data after new txns ordering
     sdk_send_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle,
                               sdk_wallet_client, CHK_FREQ)
     ensure_all_nodes_have_same_data(looper, nodes=txnPoolNodeSet)
-    # assert primary.master_last_ordered_3PC[1] == 2*CHK_FREQ + 1
+
+
+def delay_msg(nodes, delay_function, types=None):
+    for n in nodes:
+        if types is None:
+            n.nodeIbStasher.delay(delay_function(sys.maxsize))
+        else:
+            n.nodeIbStasher.delay(delay_function(sys.maxsize, types))
+
+
+def reset_delay(nodes, message):
+    for n in nodes:
+        n.nodeIbStasher.reset_delays_and_process_delayeds(message)
 
 
 def last_prepared_certificate(nodes, num):
@@ -89,20 +90,27 @@ def last_prepared_certificate(nodes, num):
         assert n.master_replica.last_prepared_certificate_in_view() == num
 
 
-def checkpoint_finish(nodes, start_pp_seq_no, end_pp_seq_no):
+def check_checkpoint_finish(nodes, start_pp_seq_no, end_pp_seq_no):
     for n in nodes:
-        # assert n.master_replica.firstCheckPoint is not None
-        # assert n.master_replica.firstCheckPoint[0] == (start_pp_seq_no,
-        #                                                end_pp_seq_no)
-        for seq_no in range(start_pp_seq_no, end_pp_seq_no):
-            assert not (0, seq_no) in n.master_replica.sentPrePrepares
+        assert (start_pp_seq_no, end_pp_seq_no) in n.master_replica.checkpoints
+        ckState = n.master_replica.checkpoints[(start_pp_seq_no, end_pp_seq_no)]
+        assert n.master_replica.quorums.checkpoint.is_reached(len(ckState.receivedDigests))
 
 
-def last_ordered_check(nodes, last_ordered):
+def last_ordered_check(nodes, last_ordered, instance_id=None):
     for n in nodes:
-        assert n.master_last_ordered_3PC == last_ordered
+        last_ordered_3pc = n.master_last_ordered_3PC \
+            if instance_id is None \
+            else n.replicas[instance_id].last_ordered_3pc
+        assert last_ordered_3pc == last_ordered
 
 
 def check_view_no(nodes, view_no):
     for n in nodes:
         assert n.viewNo == view_no
+
+
+def test_tmp(txnPoolNodeSet, looper):
+    for node in txnPoolNodeSet:
+        node.view_changer.on_master_degradation()
+        ensureElectionsDone(looper, txnPoolNodeSet)


### PR DESCRIPTION
Fix that a checkpoints finalize cleans necessary data from requests and 3pc queues  in view change before catchup.

Changes:
- add bugfix for view_no in checkpoint cleaning in view change. Choose view_no from last_ordered_3pc
- update test test_checkpoints_removal_in_view_change.py