### PR TITLE
INDY-1389: added check to case with bls key proof without key

### DIFF
--- a/plenum/server/pool_req_handler.py
+++ b/plenum/server/pool_req_handler.py
@@ -33,17 +33,16 @@ class PoolRequestHandler(LedgerRequestHandler):
             return
         blskey = request.operation.get(DATA).get(BLS_KEY, None)
         blskey_proof = request.operation.get(DATA).get(BLS_KEY_PROOF, None)
-        if blskey is None:
-            if blskey_proof is None:
-                return
-            else:
-                raise InvalidClientRequest(request.identifier, request.reqId,
-                                           "A Proof of possession is not "
-                                           "needed without BLS key")
-        elif blskey_proof is None:
-                raise InvalidClientRequest(request.identifier, request.reqId,
-                                           "A Proof of possession must be "
-                                           "provided with BLS key")
+        if blskey is None and blskey_proof is None:
+            return
+        if blskey is None and blskey_proof is not None:
+            raise InvalidClientRequest(request.identifier, request.reqId,
+                                       "A Proof of possession is not "
+                                       "needed without BLS key")
+        if blskey is not None and blskey_proof is None:
+            raise InvalidClientRequest(request.identifier, request.reqId,
+                                       "A Proof of possession must be "
+                                       "provided with BLS key")
         if not self._verify_bls_key_proof_of_possession(blskey_proof,
                                                         blskey):
             raise InvalidClientRequest(request.identifier, request.reqId,

--- a/plenum/server/pool_req_handler.py
+++ b/plenum/server/pool_req_handler.py
@@ -38,8 +38,8 @@ class PoolRequestHandler(LedgerRequestHandler):
                 return
             else:
                 raise InvalidClientRequest(request.identifier, request.reqId,
-                                           "A Proof of possession does not "
-                                           "need without BLS key")
+                                           "A Proof of possession is not "
+                                           "needed without BLS key")
         elif blskey_proof is None:
                 raise InvalidClientRequest(request.identifier, request.reqId,
                                            "A Proof of possession must be "

--- a/plenum/server/pool_req_handler.py
+++ b/plenum/server/pool_req_handler.py
@@ -38,8 +38,8 @@ class PoolRequestHandler(LedgerRequestHandler):
                 return
             else:
                 raise InvalidClientRequest(request.identifier, request.reqId,
-                                            "A Proof of possession does not "
-                                            "need without BLS key")
+                                           "A Proof of possession does not "
+                                           "need without BLS key")
         elif blskey_proof is None:
                 raise InvalidClientRequest(request.identifier, request.reqId,
                                            "A Proof of possession must be "

--- a/plenum/server/pool_req_handler.py
+++ b/plenum/server/pool_req_handler.py
@@ -32,16 +32,23 @@ class PoolRequestHandler(LedgerRequestHandler):
         if request.txn_type != NODE:
             return
         blskey = request.operation.get(DATA).get(BLS_KEY, None)
-        if blskey is None:
-            return
         blskey_proof = request.operation.get(DATA).get(BLS_KEY_PROOF, None)
-        if blskey_proof is None:
-            raise InvalidClientRequest(request.identifier, request.reqId,
-                                       "A Proof of possession must be provided with BLS key")
+        if blskey is None:
+            if blskey_proof is None:
+                return
+            else:
+                raise InvalidClientRequest(request.identifier, request.reqId,
+                                            "A Proof of possession does not "
+                                            "need without BLS key")
+        elif blskey_proof is None:
+                raise InvalidClientRequest(request.identifier, request.reqId,
+                                           "A Proof of possession must be "
+                                           "provided with BLS key")
         if not self._verify_bls_key_proof_of_possession(blskey_proof,
                                                         blskey):
             raise InvalidClientRequest(request.identifier, request.reqId,
-                                       "Proof of possession {} is incorrect for BLS key {}".
+                                       "Proof of possession {} is incorrect "
+                                       "for BLS key {}".
                                        format(blskey_proof, blskey))
 
     def validate(self, req: Request, config=None):

--- a/plenum/test/req_handler/test_pool_req_handler_static_validation.py
+++ b/plenum/test/req_handler/test_pool_req_handler_static_validation.py
@@ -72,7 +72,7 @@ def test_pool_req_handler_static_validation_with_not_full_proof(bls_keys,
                                           bls_key_proof=key_proof)
     with pytest.raises(InvalidClientRequest) as e:
         pool_req_handler.doStaticValidation(node_request)
-        assert "A Proof of possession does not need without BLS key" \
+        assert "A Proof of possession is not needed without BLS key" \
                in e._excinfo[1].args[0]
 
 

--- a/plenum/test/req_handler/test_pool_req_handler_static_validation.py
+++ b/plenum/test/req_handler/test_pool_req_handler_static_validation.py
@@ -33,7 +33,7 @@ def test_pool_req_handler_static_validation(bls_keys,
 def test_pool_req_handler_static_validation_with_full_bls(bls_keys,
                                                           pool_req_handler):
     bls_ver_key, key_proof = bls_keys
-    node_request = _generate_node_request(bls_key=None,
+    node_request = _generate_node_request(bls_key=bls_ver_key,
                                           bls_key_proof=key_proof)
     pool_req_handler.doStaticValidation(node_request)
 
@@ -58,6 +58,21 @@ def test_pool_req_handler_static_validation_with_full_proof(bls_keys,
     with pytest.raises(InvalidClientRequest) as e:
         pool_req_handler.doStaticValidation(node_request)
         assert "A Proof of possession must be provided with BLS key" \
+               in e._excinfo[1].args[0]
+
+
+def test_pool_req_handler_static_validation_with_not_full_proof(bls_keys,
+                                                                pool_req_handler):
+    '''
+    Test pool_req_handler static validation of message with not None key proof
+    and without bls key
+    '''
+    bls_ver_key, key_proof = bls_keys
+    node_request = _generate_node_request(bls_key=None,
+                                          bls_key_proof=key_proof)
+    with pytest.raises(InvalidClientRequest) as e:
+        pool_req_handler.doStaticValidation(node_request)
+        assert "A Proof of possession does not need without BLS key" \
                in e._excinfo[1].args[0]
 
 


### PR DESCRIPTION
Added to the pool_req_handler static validation of message with not None key proof and without bls key.