### PR TITLE
INDY-1681: Remove a replica that stopped because disconnected from a backup primary

### DIFF
--- a/plenum/config.py
+++ b/plenum/config.py
@@ -193,8 +193,8 @@ ToleratePrimaryDisconnection = 2
 TolerateBackupPrimaryDisconnection = 5
 
 # A node if finds itself disconnected from primary of the backup instance will
-# wait for `TimePrimaryBackupDisconnection` periods before remove the backup replica
-TimePrimaryBackupDisconnection = 6
+# wait for `TimePrimaryBackupDisconnection` seconds before remove the backup replica
+TimePrimaryBackupDisconnection = 60
 
 # Timeout factor after which a node starts requesting consistency proofs if has
 # not found enough matching

--- a/plenum/config.py
+++ b/plenum/config.py
@@ -188,6 +188,14 @@ ViewChangeWindowSize = 60
 # wait for `ToleratePrimaryDisconnection` before sending a view change message
 ToleratePrimaryDisconnection = 2
 
+# A node if finds itself disconnected from primary of the backup instance will
+# wait for `TolerateBackupPrimaryDisconnection` before remove the backup replica
+TolerateBackupPrimaryDisconnection = 5
+
+# A node if finds itself disconnected from primary of the backup instance will
+# wait for `TimePrimaryBackupDisconnection` periods before remove the backup replica
+TimePrimaryBackupDisconnection = 6
+
 # Timeout factor after which a node starts requesting consistency proofs if has
 # not found enough matching
 ConsistencyProofsTimeout = 5

--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -272,7 +272,6 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
 
         self.setPoolParams()
 
-
         self.network_i3pc_watcher.connect(self.name)
 
         self.clientBlacklister = SimpleBlacklister(
@@ -459,7 +458,6 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         self._observable = Observable()
         self._observer = NodeObserver(self)
 
-
     def init_config_ledger_and_req_handler(self):
         self.configLedger = self.getConfigLedger()
         self.init_config_state()
@@ -626,8 +624,8 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
 
         if not self.replicas.all_instances_have_primary:
             raise LogicError(
-                "{} Not all replicas have primaries: {}"
-                    .format(self, self.replicas.primaries)
+                "{} Not all replicas have "
+                "primaries: {}".format(self, self.replicas.primaries)
             )
 
         self._cancel(self._check_view_change_completed)
@@ -954,8 +952,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
     def ledger_id_for_request(self, request: Request):
         if request.operation.get(TXN_TYPE) is None:
             raise ValueError(
-                "{} TXN_TYPE is not defined for request {}"
-                    .format(self, request)
+                "{} TXN_TYPE is not defined for request {}".format(self, request)
             )
 
         typ = request.operation[TXN_TYPE]
@@ -2054,8 +2051,8 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
 
     def _update_txn_seq_range_to_3phase_after_catchup(self, ledger_id, last_caughtup_3pc):
         logger.info(
-            "{} is updating txn to batch seqNo map after catchup to {} for ledger_id {} "
-                .format(self.name, str(last_caughtup_3pc), str(ledger_id)))
+            "{} is updating txn to batch seqNo map after catchup to {} "
+            "for ledger_id {} ".format(self.name, str(last_caughtup_3pc), str(ledger_id)))
         if not last_caughtup_3pc:
             return
         # do not set if this is a 'fake' one, see replica.on_view_change_start

--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -2707,6 +2707,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
     def _schedule_backup_primary_disconnected(self, inst_id):
         if not self.disconnected_primaries:
             self._schedule(self.propose_replica_remove, self.config.TolerateBackupPrimaryDisconnection)
+        if inst_id not in self.disconnected_primaries:
             self.disconnected_primaries[inst_id] = 0
 
     # TODO: consider moving this to pool manager

--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -264,7 +264,14 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         # 3PC state consistency watchdog based on network events
         self.network_i3pc_watcher = NetworkInconsistencyWatcher(self.on_inconsistent_3pc_state_from_network)
 
+        # Need to keep track of the time when lost connection with primary,
+        # help in voting for/against a view change on the master and removing
+        # replica on the backup instance. It is supposed that a primary
+        # is lost until the primary is connected.
+        self.primaries_disconnection_times = []
+
         self.setPoolParams()
+
 
         self.network_i3pc_watcher.connect(self.name)
 
@@ -414,11 +421,6 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         # current view.
         self.msgsForFutureViews = {}
 
-        # Need to keep track of the time when lost connection with primary,
-        # help in voting for/against a view change. It is supposed that a primary
-        # is lost until the primary is connected.
-        self.lost_primary_at = time.perf_counter()
-
         plugins_to_load = self.config.PluginsToLoad if hasattr(self.config, "PluginsToLoad") else None
         tp = loadPlugins(self.plugins_dir, plugins_to_load)
         logger.info("total plugins loaded in node: {}".format(tp))
@@ -452,11 +454,11 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
 
         HookManager.__init__(self, NodeHooks.get_all_vals())
 
+        self.primaries_disconnection_times[self.master_replica.instId] = time.perf_counter()
+
         self._observable = Observable()
         self._observer = NodeObserver(self)
 
-        # Dict to store time which backup primaries were disconnected
-        self.disconnected_primaries = dict()
 
     def init_config_ledger_and_req_handler(self):
         self.configLedger = self.getConfigLedger()
@@ -625,7 +627,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         if not self.replicas.all_instances_have_primary:
             raise LogicError(
                 "{} Not all replicas have primaries: {}"
-                .format(self, self.replicas.primaries)
+                    .format(self, self.replicas.primaries)
             )
 
         self._cancel(self._check_view_change_completed)
@@ -649,8 +651,8 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         for inst_id, replica in self.replicas:
             if not replica.isMaster and replica.primaryName is not None and \
                     replica.primaryName.replace(":" + str(inst_id), "") \
-                    in self.nodestack.remotes.keys():
-                self._schedule_backup_primary_disconnected(inst_id)
+                    in list(set(self.nodestack.remotes.keys()) - self.nodestack.conns):
+                self._schedule_propose_replica_remove(inst_id)
 
     def on_inconsistent_3pc_state_from_network(self):
         if self.config.ENABLE_INCONSISTENCY_WATCHER_NETWORK:
@@ -728,6 +730,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         self.totalNodes = len(self.allNodeNames)
         self.f = getMaxFailures(self.totalNodes)
         self.requiredNumberOfInstances = self.f + 1  # per RBFT
+        self.update_primaries_disconnection_times_size()
         self.minimumNodes = (2 * self.f) + 1  # minimum for a functional pool
         self.quorums = Quorums(self.totalNodes)
         logger.info(
@@ -952,7 +955,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         if request.operation.get(TXN_TYPE) is None:
             raise ValueError(
                 "{} TXN_TYPE is not defined for request {}"
-                .format(self, request)
+                    .format(self, request)
             )
 
         typ = request.operation[TXN_TYPE]
@@ -995,7 +998,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         self.logNodeInfo()
 
     def schedule_initial_propose_view_change(self):
-        self.lost_primary_at = time.perf_counter()
+        self.primaries_disconnection_times[self.master_replica.instId] = time.perf_counter()
         self._schedule(action=self.propose_view_change,
                        seconds=self.config.INITIAL_PROPOSE_VIEW_CHANGE_TIMEOUT)
 
@@ -1272,17 +1275,17 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         self.elector.nodeCount = self.connectedNodeCount
 
         if self.master_primary_name in joined:
-            self.lost_primary_at = None
+            self.primaries_disconnection_times[self.master_replica.instId] = None
 
         for inst_id, replica in self.replicas:
             if not replica.isMaster and replica.primaryName is not None and \
                     replica.primaryName.replace(":" + str(inst_id), "") in left:
-                self._schedule_backup_primary_disconnected(inst_id)
+                self._schedule_propose_replica_remove(inst_id)
         if self.master_primary_name in left:
             logger.display('{} lost connection to primary of master'.format(self))
             self.lost_master_primary()
         elif _prev_status == Status.starting and self.status == Status.started_hungry \
-                and self.lost_primary_at is not None \
+                and self.primaries_disconnection_times[self.master_replica.instId] is not None \
                 and self.master_primary_name is not None:
             """
             Such situation may occur if the pool has come back to reachable consensus but
@@ -1430,7 +1433,6 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         return newReplicas
 
     def restore_replicas(self):
-        self.disconnected_primaries.clear()
         for inst_id in range(0, self.requiredNumberOfInstances):
             if inst_id not in self.replicas.keys():
                 self.replicas.add_replica(inst_id)
@@ -2053,7 +2055,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
     def _update_txn_seq_range_to_3phase_after_catchup(self, ledger_id, last_caughtup_3pc):
         logger.info(
             "{} is updating txn to batch seqNo map after catchup to {} for ledger_id {} "
-            .format(self.name, str(last_caughtup_3pc), str(ledger_id)))
+                .format(self.name, str(last_caughtup_3pc), str(ledger_id)))
         if not last_caughtup_3pc:
             return
         # do not set if this is a 'fake' one, see replica.on_view_change_start
@@ -2661,17 +2663,17 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         if instance_id == 0:
             # TODO: 0 should be replaced with configurable constant
             self.monitor.hasMasterPrimary = self.has_master_primary
-        if not self.lost_primary_at:
+        if not self.primaries_disconnection_times[self.master_replica.instId]:
             return
         if self.nodestack.isConnectedTo(self.master_primary_name) or \
                 self.master_primary_name == self.name:
-            self.lost_primary_at = None
+            self.primaries_disconnection_times[self.master_replica.instId] = None
 
     def propose_view_change(self):
         # Sends instance change message when primary has been
         # disconnected for long enough
         self._cancel(self.propose_view_change)
-        if not self.lost_primary_at:
+        if not self.primaries_disconnection_times[self.master_replica.instId]:
             logger.info('{} The primary is already connected '
                         'so view change will not be proposed'.format(self))
             return
@@ -2687,19 +2689,18 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         self.view_changer.on_primary_loss()
 
     def propose_replica_remove(self):
-        if not self.disconnected_primaries:
+        if all(t is None for t in self.primaries_disconnection_times):
             self._cancel(self.propose_replica_remove)
             return
-        for inst_id in dict(self.disconnected_primaries).keys():
-            if self.replicas[inst_id].primaryName is None:
+        for inst_id in range(1, len(self.primaries_disconnection_times)):
+            if inst_id not in self.replicas.keys() or self.replicas[inst_id].primaryName is None:
                 continue
             primary_name = self.replicas[inst_id].primaryName.replace(":" + str(inst_id), "")
-            if primary_name not in self.nodestack.remotes.keys():
-                del self.disconnected_primaries[inst_id]
-            elif time.perf_counter() - self.disconnected_primaries[inst_id] > \
+            if primary_name not in list(set(self.nodestack.remotes.keys()) - self.nodestack.conns):
+                self.primaries_disconnection_times[inst_id] = None
+            elif time.perf_counter() - self.primaries_disconnection_times[inst_id] > \
                     self.config.TimePrimaryBackupDisconnection:
                 self.replicas.remove_replica(inst_id)
-                del self.disconnected_primaries[inst_id]
         self._schedule(self.propose_replica_remove,
                        self.config.TolerateBackupPrimaryDisconnection)
 
@@ -2708,11 +2709,11 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         self._schedule(self.propose_view_change,
                        self.config.ToleratePrimaryDisconnection)
 
-    def _schedule_backup_primary_disconnected(self, inst_id):
-        if not self.disconnected_primaries:
+    def _schedule_propose_replica_remove(self, inst_id):
+        if all(t is None for t in self.primaries_disconnection_times):
             self._schedule(self.propose_replica_remove, self.config.TolerateBackupPrimaryDisconnection)
-        if inst_id not in self.disconnected_primaries:
-            self.disconnected_primaries[inst_id] = time.perf_counter()
+        if self.primaries_disconnection_times[inst_id] is None:
+            self.primaries_disconnection_times[inst_id] = time.perf_counter()
 
     # TODO: consider moving this to pool manager
     def lost_master_primary(self):
@@ -2720,7 +2721,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         Schedule an primary connection check which in turn can send a view
         change message
         """
-        self.lost_primary_at = time.perf_counter()
+        self.primaries_disconnection_times[self.master_replica.instId] = time.perf_counter()
         self._schedule_view_change()
 
     def select_primaries(self, nodeReg: Dict[str, HA]=None):
@@ -2746,7 +2747,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
                 logger.debug('{} already has a primary'.format(replica))
                 continue
             if instance_id == 0:
-                new_primary_name, new_primary_instance_name =\
+                new_primary_name, new_primary_instance_name = \
                     self.elector.next_primary_replica_name_for_master(nodeReg=nodeReg)
                 primary_rank = self.get_rank_by_name(
                     new_primary_name, nodeReg)
@@ -2754,7 +2755,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
                 # to return name and rank at once and remove assert
                 assert primary_rank is not None
             else:
-                new_primary_name, new_primary_instance_name =\
+                new_primary_name, new_primary_instance_name = \
                     self.elector.next_primary_replica_name_for_backup(
                         instance_id, primary_rank, primaries, nodeReg=nodeReg)
             primaries.add(new_primary_name)
@@ -3300,7 +3301,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
 
     def transform_txn_for_ledger(self, txn):
         txn_type = get_type(txn)
-        return self.get_req_handler(txn_type=txn_type).\
+        return self.get_req_handler(txn_type=txn_type). \
             transform_txn_for_ledger(txn)
 
     def __enter__(self):
@@ -3383,3 +3384,9 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
 
     def get_observers(self, observer_policy_type: ObserverSyncPolicyType):
         return self._observable.get_observers(observer_policy_type)
+
+    def update_primaries_disconnection_times_size(self):
+        while self.requiredNumberOfInstances > len(self.primaries_disconnection_times):
+            self.primaries_disconnection_times.append(None)
+        while self.requiredNumberOfInstances < len(self.primaries_disconnection_times):
+            self.primaries_disconnection_times.pop()

--- a/plenum/server/view_change/view_changer.py
+++ b/plenum/server/view_change/view_changer.py
@@ -706,5 +706,5 @@ class ViewChanger(HasActionQueue, MessageProcessor):
 
     def is_primary_disconnected(self):
         return \
-            self.node.lost_primary_at and self.node.master_primary_name and \
+            self.node.primaries_disconnection_times[self.node.master_replica.instId] and self.node.master_primary_name and \
             self.node.master_primary_name not in self.node.nodestack.conns

--- a/plenum/test/node_request/test_quorum_f_plus_2_nodes_but_not_primary_off_and_on.py
+++ b/plenum/test/node_request/test_quorum_f_plus_2_nodes_but_not_primary_off_and_on.py
@@ -83,7 +83,7 @@ def test_quorum_after_f_plus_2_nodes_but_not_primary_turned_off_and_later_on(
 
     nodes[3] = start_stopped_node(nodes[3], looper, tconf, tdir, allPluginsPath)
     ensureElectionsDone(looper, nodes[:2] + nodes[3:],
-                        numInstances=getRequiredInstances(nodeCount))
+                        instances_list=range(getRequiredInstances(nodeCount)))
     checkViewNoForNodes(nodes[:2] + nodes[3:], expectedViewNo=0)
 
     sdk_reqs6 = sdk_send_random_requests(looper,
@@ -94,7 +94,7 @@ def test_quorum_after_f_plus_2_nodes_but_not_primary_turned_off_and_later_on(
 
     nodes[2] = start_stopped_node(nodes[2], looper, tconf, tdir, allPluginsPath)
     ensureElectionsDone(looper, nodes,
-                        numInstances=getRequiredInstances(nodeCount))
+                        instances_list=range(getRequiredInstances(nodeCount)))
     checkViewNoForNodes(nodes, expectedViewNo=0)
 
     sdk_send_random_and_check(looper, txnPoolNodeSet,

--- a/plenum/test/node_request/test_quorum_f_plus_2_nodes_including_primary_off_and_on.py
+++ b/plenum/test/node_request/test_quorum_f_plus_2_nodes_including_primary_off_and_on.py
@@ -38,7 +38,7 @@ def test_quorum_after_f_plus_2_nodes_including_primary_turned_off_and_later_on(
     stop_node(nodes[0], looper, nodes)
     waitForViewChange(looper, nodes[1:], expectedViewNo=1)
     ensureElectionsDone(looper, nodes[1:],
-                        numInstances=getRequiredInstances(nodeCount))
+                        instances_list=range(getRequiredInstances(nodeCount)))
 
     sdk_send_random_and_check(looper, txnPoolNodeSet,
                               sdk_pool_handle,
@@ -85,7 +85,7 @@ def test_quorum_after_f_plus_2_nodes_including_primary_turned_off_and_later_on(
 
     nodes[1] = start_stopped_node(nodes[1], looper, tconf, tdir, allPluginsPath)
     ensureElectionsDone(looper, nodes[1:],
-                        numInstances=getRequiredInstances(nodeCount),
+                        instances_list=range(getRequiredInstances(nodeCount)),
                         customTimeout=60)
     checkViewNoForNodes(nodes[1:], expectedViewNo=1)
 
@@ -96,7 +96,7 @@ def test_quorum_after_f_plus_2_nodes_including_primary_turned_off_and_later_on(
 
     nodes[0] = start_stopped_node(nodes[0], looper, tconf, tdir, allPluginsPath)
     ensureElectionsDone(looper, nodes,
-                        numInstances=getRequiredInstances(nodeCount),
+                        instances_list=range(getRequiredInstances(nodeCount)),
                         customTimeout=60)
     checkViewNoForNodes(nodes, expectedViewNo=1)
 

--- a/plenum/test/primary_selection/test_catchup_after_view_change.py
+++ b/plenum/test/primary_selection/test_catchup_after_view_change.py
@@ -76,7 +76,7 @@ def test_slow_nodes_catchup_before_selecting_primary_in_new_view(
     ensure_view_change(looper, txnPoolNodeSet)
     # `slow_node` will not have elections done but others will.
     checkProtocolInstanceSetup(looper, fast_nodes,
-                               numInstances=len(slow_node.replicas),
+                               instances=list(slow_node.replicas.keys()),
                                retryWait=1)
     ensure_all_nodes_have_same_data(looper, nodes=txnPoolNodeSet)
 

--- a/plenum/test/primary_selection/test_recover_more_than_f_failure.py
+++ b/plenum/test/primary_selection/test_recover_more_than_f_failure.py
@@ -32,7 +32,7 @@ def test_recover_stop_primaries(looper, checkpoint_size, txnPoolNodeSet,
     logger.info("Make sure view changed")
     expected_view_no = initial_view_no + 1
     waitForViewChange(looper, active_nodes, expectedViewNo=expected_view_no)
-    ensureElectionsDone(looper=looper, nodes=active_nodes, numInstances=2)
+    ensureElectionsDone(looper=looper, nodes=active_nodes, instances_list=2)
     ensure_all_nodes_have_same_data(looper, nodes=active_nodes)
 
     logger.info("send at least one checkpoint")
@@ -53,7 +53,7 @@ def test_recover_stop_primaries(looper, checkpoint_size, txnPoolNodeSet,
 
     logger.info("Check that primary selected")
     ensureElectionsDone(looper=looper, nodes=active_nodes,
-                        numInstances=2, customTimeout=30)
+                        instances_list=2, customTimeout=30)
     waitForViewChange(looper, active_nodes, expectedViewNo=expected_view_no)
     ensure_all_nodes_have_same_data(looper, nodes=active_nodes)
 

--- a/plenum/test/primary_selection/test_recover_more_than_f_failure.py
+++ b/plenum/test/primary_selection/test_recover_more_than_f_failure.py
@@ -32,7 +32,7 @@ def test_recover_stop_primaries(looper, checkpoint_size, txnPoolNodeSet,
     logger.info("Make sure view changed")
     expected_view_no = initial_view_no + 1
     waitForViewChange(looper, active_nodes, expectedViewNo=expected_view_no)
-    ensureElectionsDone(looper=looper, nodes=active_nodes, instances_list=2)
+    ensureElectionsDone(looper=looper, nodes=active_nodes, instances_list=range(2))
     ensure_all_nodes_have_same_data(looper, nodes=active_nodes)
 
     logger.info("send at least one checkpoint")
@@ -53,7 +53,7 @@ def test_recover_stop_primaries(looper, checkpoint_size, txnPoolNodeSet,
 
     logger.info("Check that primary selected")
     ensureElectionsDone(looper=looper, nodes=active_nodes,
-                        instances_list=2, customTimeout=30)
+                        instances_list=range(2), customTimeout=30)
     waitForViewChange(looper, active_nodes, expectedViewNo=expected_view_no)
     ensure_all_nodes_have_same_data(looper, nodes=active_nodes)
 

--- a/plenum/test/primary_selection/test_recover_primary_no_view_change.py
+++ b/plenum/test/primary_selection/test_recover_primary_no_view_change.py
@@ -56,7 +56,7 @@ def test_recover_stop_primaries_no_view_change(looper, checkpoint_size, txnPoolN
 
     logger.info("Check that primary selected")
     ensureElectionsDone(looper=looper, nodes=active_nodes,
-                        numInstances=2, customTimeout=30)
+                        instances_list=range(2), customTimeout=30)
     waitForViewChange(looper, active_nodes, expectedViewNo=0)
     ensure_all_nodes_have_same_data(looper, nodes=active_nodes)
 

--- a/plenum/test/primary_selection/test_selection_f_plus_one_quorum.py
+++ b/plenum/test/primary_selection/test_selection_f_plus_one_quorum.py
@@ -34,7 +34,7 @@ def test_selection_f_plus_one_quorum(looper, txnPoolNodeSet, allPluginsPath,
 
     # Make nodes to perform view change
     ensure_view_change(looper, non_lagging_nodes)
-    ensureElectionsDone(looper=looper, nodes=non_lagging_nodes, instances_list=2)
+    ensureElectionsDone(looper=looper, nodes=non_lagging_nodes, instances_list=range(2))
     ensure_all_nodes_have_same_data(looper, nodes=non_lagging_nodes)
 
     # Stop two more of active nodes
@@ -53,7 +53,7 @@ def test_selection_f_plus_one_quorum(looper, txnPoolNodeSet, allPluginsPath,
     # Check that primary selected
     expected_view_no = initial_view_no + 1
     ensureElectionsDone(looper=looper, nodes=active_nodes,
-                        instances_list=2, customTimeout=30)
+                        instances_list=range(2), customTimeout=30)
     waitForViewChange(looper, active_nodes, expectedViewNo=expected_view_no)
 
     sdk_send_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle, sdk_wallet_client, 1)

--- a/plenum/test/primary_selection/test_selection_f_plus_one_quorum.py
+++ b/plenum/test/primary_selection/test_selection_f_plus_one_quorum.py
@@ -34,7 +34,7 @@ def test_selection_f_plus_one_quorum(looper, txnPoolNodeSet, allPluginsPath,
 
     # Make nodes to perform view change
     ensure_view_change(looper, non_lagging_nodes)
-    ensureElectionsDone(looper=looper, nodes=non_lagging_nodes, numInstances=2)
+    ensureElectionsDone(looper=looper, nodes=non_lagging_nodes, instances_list=2)
     ensure_all_nodes_have_same_data(looper, nodes=non_lagging_nodes)
 
     # Stop two more of active nodes
@@ -53,7 +53,7 @@ def test_selection_f_plus_one_quorum(looper, txnPoolNodeSet, allPluginsPath,
     # Check that primary selected
     expected_view_no = initial_view_no + 1
     ensureElectionsDone(looper=looper, nodes=active_nodes,
-                        numInstances=2, customTimeout=30)
+                        instances_list=2, customTimeout=30)
     waitForViewChange(looper, active_nodes, expectedViewNo=expected_view_no)
 
     sdk_send_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle, sdk_wallet_client, 1)

--- a/plenum/test/replica/helper.py
+++ b/plenum/test/replica/helper.py
@@ -26,3 +26,19 @@ def create_preprepare(replica, sdk_wallet_steward, req_count):
     replica.last_accepted_pre_prepare_time = int(time.time())
     pp = replica.create3PCBatch(DOMAIN_LEDGER_ID)
     return reqs, pp
+
+
+def check_replica_removed(node, start_replicas_count, instance_id):
+    replicas_count = start_replicas_count - 1
+    assert node.replicas.num_replicas == replicas_count
+    replicas_lists = [node.replicas.keys(),
+                      node.replicas._messages_to_replicas.keys(),
+                      node.monitor.numOrderedRequests.keys(),
+                      node.monitor.clientAvgReqLatencies.keys(),
+                      node.monitor.throughputs.keys(),
+                      node.monitor.requestTracker.instances_ids,
+                      node.monitor.instances.ids]
+    assert all(instance_id not in replicas for replicas in replicas_lists)
+    if node.monitor.acc_monitor is not None:
+        assert node.monitor.acc_monitor == replicas_count
+        assert instance_id not in node.replicas.keys()

--- a/plenum/test/replica/test_replica_removing_after_node_started.py
+++ b/plenum/test/replica/test_replica_removing_after_node_started.py
@@ -1,0 +1,87 @@
+import pytest
+
+from plenum.test.node_catchup.helper import waitNodeDataEquality
+from plenum.test.node_catchup.test_config_ledger import start_stopped_node
+from plenum.test.pool_transactions.helper import disconnect_node_and_ensure_disconnected, sdk_add_new_steward_and_node
+from plenum.test.replica.helper import check_replica_removed
+from stp_core.loop.eventually import eventually
+from plenum.test.helper import waitForViewChange
+from plenum.test.test_node import ensureElectionsDone, checkNodesConnected
+
+nodeCount = 7
+
+
+@pytest.fixture(scope="module")
+def tconf(tconf):
+    old_time = tconf.TimePrimaryBackupDisconnection
+    tconf.TimePrimaryBackupDisconnection = 5
+    yield tconf
+    tconf.TimePrimaryBackupDisconnection = old_time
+
+
+def test_replica_removing_after_node_started(looper,
+                                      txnPoolNodeSet,
+                                      sdk_pool_handle,
+                                      sdk_wallet_client,
+                                      tconf,
+                                      tdir,
+                                      allPluginsPath,
+                                      sdk_wallet_steward):
+    """
+    1. Remove backup primary node.
+    2. Check that replicas with the disconnected primary were removed.
+    3. Add new node
+    4. Check that in the new node the replica with the disconnected primary were removed.
+    3. Recover the removed node.
+    4. Start View Change.
+    5. Check that all replicas were restored.
+    """
+    start_replicas_count = txnPoolNodeSet[0].replicas.num_replicas
+    instance_to_remove = txnPoolNodeSet[0].requiredNumberOfInstances - 1
+    removed_primary_node = txnPoolNodeSet[instance_to_remove]
+    # remove backup primary node.
+    disconnect_node_and_ensure_disconnected(looper, txnPoolNodeSet, removed_primary_node)
+    txnPoolNodeSet.remove(removed_primary_node)
+    looper.removeProdable(removed_primary_node)
+
+    # check that replicas were removed
+    def check_replica_removed_on_all_nodes(inst_id=instance_to_remove):
+        for node in txnPoolNodeSet:
+            check_replica_removed(node,
+                                  start_replicas_count,
+                                  inst_id)
+            assert not node.monitor.isMasterDegraded()
+            assert len(node.requests) == 0
+
+    looper.run(eventually(check_replica_removed_on_all_nodes,
+                          timeout=tconf.TimePrimaryBackupDisconnection * 2))
+
+    new_steward_wallet, new_node = sdk_add_new_steward_and_node(looper,
+                                                                sdk_pool_handle,
+                                                                sdk_wallet_steward,
+                                                                "test_steward",
+                                                                "test_node",
+                                                                tdir,
+                                                                tconf,
+                                                                allPluginsPath)
+    txnPoolNodeSet.append(new_node)
+    looper.run(checkNodesConnected(txnPoolNodeSet))
+    waitNodeDataEquality(looper, new_node, *txnPoolNodeSet[:-1])
+    looper.run(eventually(check_replica_removed,
+                          new_node,
+                          start_replicas_count,
+                          instance_to_remove,
+                          timeout=100))
+
+    # recover the removed node
+    removed_primary_node = start_stopped_node(removed_primary_node, looper, tconf,
+                                              tdir, allPluginsPath)
+    txnPoolNodeSet.append(removed_primary_node)
+    looper.run(checkNodesConnected(txnPoolNodeSet))
+    # start View Change
+    for node in txnPoolNodeSet:
+        node.view_changer.on_master_degradation()
+    ensureElectionsDone(looper=looper, nodes=txnPoolNodeSet,
+                        instances_list=range(txnPoolNodeSet[0].requiredNumberOfInstances),
+                        customTimeout=tconf.TimePrimaryBackupDisconnection * 2)
+    assert start_replicas_count == removed_primary_node.replicas.num_replicas

--- a/plenum/test/replica/test_replica_removing_after_view_change.py
+++ b/plenum/test/replica/test_replica_removing_after_view_change.py
@@ -1,0 +1,86 @@
+import pytest
+
+from plenum.test.node_catchup.helper import waitNodeDataEquality
+from plenum.test.node_catchup.test_config_ledger import start_stopped_node
+from plenum.test.pool_transactions.helper import disconnect_node_and_ensure_disconnected, sdk_add_new_steward_and_node
+from plenum.test.replica.helper import check_replica_removed
+from stp_core.loop.eventually import eventually
+from plenum.test.helper import waitForViewChange
+from plenum.test.test_node import ensureElectionsDone, checkNodesConnected
+
+nodeCount = 7
+
+
+@pytest.fixture(scope="module")
+def tconf(tconf):
+    old_time = tconf.TimePrimaryBackupDisconnection
+    tconf.TimePrimaryBackupDisconnection = 5
+    yield tconf
+    tconf.TimePrimaryBackupDisconnection = old_time
+
+
+def test_replica_removing_with_primary_disconnected(looper,
+                                                    txnPoolNodeSet,
+                                                    sdk_pool_handle,
+                                                    sdk_wallet_client,
+                                                    tconf,
+                                                    tdir,
+                                                    allPluginsPath):
+    """
+    1. Remove backup primary node.
+    2. Check that replicas with the disconnected primary were removed.
+    3. Start View Change.
+    4. Check that the new replica with disconnected primary is removed and
+    other replicas are working correctly.
+    5. Recover the removed node.
+    6. Start View Change.
+    7. Check that all replicas were restored.
+    """
+    start_replicas_count = txnPoolNodeSet[0].replicas.num_replicas
+    instance_to_remove = txnPoolNodeSet[0].requiredNumberOfInstances - 1
+    removed_node = txnPoolNodeSet[instance_to_remove]
+    # remove backup primary node.
+    disconnect_node_and_ensure_disconnected(looper, txnPoolNodeSet, removed_node)
+    txnPoolNodeSet.remove(removed_node)
+    looper.removeProdable(removed_node)
+
+    # check that replicas were removed
+    def check_replica_removed_on_all_nodes(inst_id=instance_to_remove):
+        for n in txnPoolNodeSet:
+            check_replica_removed(n,
+                                  start_replicas_count,
+                                  inst_id)
+            assert not n.monitor.isMasterDegraded()
+            assert len(n.requests) == 0
+
+    looper.run(eventually(check_replica_removed_on_all_nodes,
+                          timeout=tconf.TimePrimaryBackupDisconnection * 2))
+
+    # start View Change
+    for node in txnPoolNodeSet:
+        node.view_changer.on_master_degradation()
+    waitForViewChange(looper, txnPoolNodeSet, expectedViewNo=1,
+                      customTimeout=2 * tconf.VIEW_CHANGE_TIMEOUT)
+    instance_to_remove -= 1
+    instances = list(range(txnPoolNodeSet[0].requiredNumberOfInstances))
+    instances.remove(instance_to_remove)
+    ensureElectionsDone(looper=looper, nodes=txnPoolNodeSet,
+                        instances_list=instances,
+                        customTimeout=tconf.TimePrimaryBackupDisconnection * 4)
+    # check that all replicas were restored
+    looper.run(eventually(check_replica_removed_on_all_nodes,
+                          instance_to_remove,
+                          timeout=tconf.TimePrimaryBackupDisconnection * 2))
+
+    # recover the removed node
+    removed_node = start_stopped_node(removed_node, looper, tconf,
+                                      tdir, allPluginsPath)
+    txnPoolNodeSet.append(removed_node)
+    looper.run(checkNodesConnected(txnPoolNodeSet))
+    # start View Change
+    for node in txnPoolNodeSet:
+        node.view_changer.on_master_degradation()
+    ensureElectionsDone(looper=looper, nodes=txnPoolNodeSet,
+                        instances_list=range(txnPoolNodeSet[0].requiredNumberOfInstances),
+                        customTimeout=tconf.TimePrimaryBackupDisconnection * 2)
+    assert start_replicas_count == removed_node.replicas.num_replicas

--- a/plenum/test/replica/test_replica_removing_with_primary_disconnected.py
+++ b/plenum/test/replica/test_replica_removing_with_primary_disconnected.py
@@ -11,7 +11,7 @@ from plenum.test.test_node import ensureElectionsDone, checkNodesConnected
 @pytest.fixture(scope="module")
 def tconf(tconf):
     old_time = tconf.TimePrimaryBackupDisconnection
-    tconf.TimePrimaryBackupDisconnection = 2
+    tconf.TimePrimaryBackupDisconnection = 5
     yield tconf
     tconf.TimePrimaryBackupDisconnection = old_time
 
@@ -45,8 +45,7 @@ def test_replica_removing_with_primary_disconnected(looper,
                                   start_replicas_count,
                                   instance_to_remove)
     looper.run(eventually(check_replica_removed_on_all_nodes,
-                          timeout=tconf.TimePrimaryBackupDisconnection *
-                                  tconf.TolerateBackupPrimaryDisconnection * 4))
+                          timeout=tconf.TimePrimaryBackupDisconnection * 4))
     assert not node.monitor.isMasterDegraded()
     assert len(node.requests) == 0
 

--- a/plenum/test/replica/test_replica_removing_with_primary_disconnected.py
+++ b/plenum/test/replica/test_replica_removing_with_primary_disconnected.py
@@ -1,0 +1,65 @@
+import pytest
+
+from plenum.test.node_catchup.test_config_ledger import start_stopped_node
+from plenum.test.pool_transactions.helper import disconnect_node_and_ensure_disconnected
+from plenum.test.replica.helper import check_replica_removed
+from stp_core.loop.eventually import eventually
+from plenum.test.helper import waitForViewChange
+from plenum.test.test_node import ensureElectionsDone, checkNodesConnected
+
+
+@pytest.fixture(scope="module")
+def tconf(tconf):
+    old_time = tconf.TimePrimaryBackupDisconnection
+    tconf.TimePrimaryBackupDisconnection = 2
+    yield tconf
+    tconf.TimePrimaryBackupDisconnection = old_time
+
+
+def test_replica_removing_with_primary_disconnected(looper,
+                                                    txnPoolNodeSet,
+                                                    sdk_pool_handle,
+                                                    sdk_wallet_client,
+                                                    tconf,
+                                                    tdir,
+                                                    allPluginsPath):
+    """
+    1. Remove backup primary node.
+    2. Check that replicas with the disconnected primary were removed.
+    3. Recover the removed node.
+    4. Start View Change.
+    5. Check that all replicas were restored.
+    """
+    start_replicas_count = txnPoolNodeSet[0].replicas.num_replicas
+    instance_to_remove = 1
+    node = txnPoolNodeSet[instance_to_remove]
+    # remove backup primary node.
+    disconnect_node_and_ensure_disconnected(looper, txnPoolNodeSet, node)
+    txnPoolNodeSet.remove(node)
+    looper.removeProdable(node)
+
+    # check that replicas were removed
+    def check_replica_removed_on_all_nodes():
+        for node in txnPoolNodeSet:
+            check_replica_removed(node,
+                                  start_replicas_count,
+                                  instance_to_remove)
+    looper.run(eventually(check_replica_removed_on_all_nodes,
+                          timeout=tconf.TimePrimaryBackupDisconnection *
+                                  tconf.TolerateBackupPrimaryDisconnection * 4))
+    assert not node.monitor.isMasterDegraded()
+    assert len(node.requests) == 0
+
+    # recover the removed node
+    node = start_stopped_node(node, looper, tconf,
+                              tdir, allPluginsPath)
+    txnPoolNodeSet.append(node)
+    looper.run(checkNodesConnected(txnPoolNodeSet))
+    # start View Change
+    for node in txnPoolNodeSet:
+        node.view_changer.on_master_degradation()
+    waitForViewChange(looper, txnPoolNodeSet, expectedViewNo=1,
+                      customTimeout=2 * tconf.VIEW_CHANGE_TIMEOUT)
+    ensureElectionsDone(looper=looper, nodes=txnPoolNodeSet)
+    # check that all replicas were restored
+    assert start_replicas_count == node.replicas.num_replicas

--- a/plenum/test/restart/test_restart_to_inconsistent_state.py
+++ b/plenum/test/restart/test_restart_to_inconsistent_state.py
@@ -32,7 +32,7 @@ def test_restart_majority_to_same_view(looper, txnPoolNodeSet, tconf, tdir, allP
     majority_before_restart = majority.copy()
     restart_nodes(looper, txnPoolNodeSet, majority, tconf, tdir, allPluginsPath,
                   after_restart_timeout=tm, start_one_by_one=False, wait_for_elections=False)
-    ensureElectionsDone(looper, majority, numInstances=2)
+    ensureElectionsDone(looper, majority, instances_list=range(2))
 
     # Check that nodes in minority group are aware that they might have inconsistent 3PC state
     for node in minority:
@@ -70,7 +70,7 @@ def test_restart_majority_to_lower_view(looper, txnPoolNodeSet, tconf, tdir, all
     majority_before_restart = majority.copy()
     restart_nodes(looper, txnPoolNodeSet, majority, tconf, tdir, allPluginsPath,
                   after_restart_timeout=tm, start_one_by_one=False, wait_for_elections=False)
-    ensureElectionsDone(looper, majority, numInstances=2)
+    ensureElectionsDone(looper, majority, instances_list=range(2))
 
     # Check that nodes in minority group are aware that they might have inconsistent 3PC state
     for node in minority:

--- a/plenum/test/restart/test_restart_to_same_view_with_killed_primary.py
+++ b/plenum/test/restart/test_restart_to_same_view_with_killed_primary.py
@@ -37,7 +37,7 @@ def test_restart_to_same_view_with_killed_primary(looper, txnPoolNodeSet, tconf,
     looper.removeProdable(primary)
     ensure_node_disconnected(looper, primary, txnPoolNodeSet)
     waitForViewChange(looper, alive_nodes, 1, customTimeout=VIEW_CHANGE_TIMEOUT)
-    ensureElectionsDone(looper, alive_nodes, numInstances=3)
+    ensureElectionsDone(looper, alive_nodes, instances_list=3)
 
     # Add transaction to ledger
     sdk_send_random_and_check(looper, alive_nodes, sdk_pool_handle, sdk_wallet_client, 1)
@@ -47,7 +47,7 @@ def test_restart_to_same_view_with_killed_primary(looper, txnPoolNodeSet, tconf,
     restart_nodes(looper, alive_nodes, majority, tconf, tdir, allPluginsPath,
                   after_restart_timeout=restart_timeout, start_one_by_one=False, wait_for_elections=False)
     waitForViewChange(looper, majority, 1, customTimeout=2.1 * VIEW_CHANGE_TIMEOUT)
-    ensureElectionsDone(looper, majority, numInstances=3)
+    ensureElectionsDone(looper, majority, instances_list=3)
 
     # Check that nodes in minority group are aware that they might have inconsistent 3PC state
     for node in minority:
@@ -64,7 +64,7 @@ def test_restart_to_same_view_with_killed_primary(looper, txnPoolNodeSet, tconf,
     # Restart minority group
     restart_nodes(looper, alive_nodes, minority, tconf, tdir, allPluginsPath,
                   after_restart_timeout=restart_timeout, start_one_by_one=False, wait_for_elections=False)
-    ensureElectionsDone(looper, alive_nodes, numInstances=3)
+    ensureElectionsDone(looper, alive_nodes, instances_list=3)
 
     # Check that all nodes are still functional
     sdk_ensure_pool_functional(looper, alive_nodes, sdk_wallet_client, sdk_pool_handle)

--- a/plenum/test/restart/test_restart_to_same_view_with_killed_primary.py
+++ b/plenum/test/restart/test_restart_to_same_view_with_killed_primary.py
@@ -37,7 +37,7 @@ def test_restart_to_same_view_with_killed_primary(looper, txnPoolNodeSet, tconf,
     looper.removeProdable(primary)
     ensure_node_disconnected(looper, primary, txnPoolNodeSet)
     waitForViewChange(looper, alive_nodes, 1, customTimeout=VIEW_CHANGE_TIMEOUT)
-    ensureElectionsDone(looper, alive_nodes, instances_list=3)
+    ensureElectionsDone(looper, alive_nodes, instances_list=range(3))
 
     # Add transaction to ledger
     sdk_send_random_and_check(looper, alive_nodes, sdk_pool_handle, sdk_wallet_client, 1)
@@ -47,7 +47,7 @@ def test_restart_to_same_view_with_killed_primary(looper, txnPoolNodeSet, tconf,
     restart_nodes(looper, alive_nodes, majority, tconf, tdir, allPluginsPath,
                   after_restart_timeout=restart_timeout, start_one_by_one=False, wait_for_elections=False)
     waitForViewChange(looper, majority, 1, customTimeout=2.1 * VIEW_CHANGE_TIMEOUT)
-    ensureElectionsDone(looper, majority, instances_list=3)
+    ensureElectionsDone(looper, majority, instances_list=range(3))
 
     # Check that nodes in minority group are aware that they might have inconsistent 3PC state
     for node in minority:
@@ -64,7 +64,7 @@ def test_restart_to_same_view_with_killed_primary(looper, txnPoolNodeSet, tconf,
     # Restart minority group
     restart_nodes(looper, alive_nodes, minority, tconf, tdir, allPluginsPath,
                   after_restart_timeout=restart_timeout, start_one_by_one=False, wait_for_elections=False)
-    ensureElectionsDone(looper, alive_nodes, instances_list=3)
+    ensureElectionsDone(looper, alive_nodes, instances_list=range(3))
 
     # Check that all nodes are still functional
     sdk_ensure_pool_functional(looper, alive_nodes, sdk_wallet_client, sdk_pool_handle)

--- a/plenum/test/test_node.py
+++ b/plenum/test/test_node.py
@@ -814,8 +814,8 @@ def checkEveryProtocolInstanceHasOnlyOnePrimary(looper: Looper,
                                                 nodes: Sequence[TestNode],
                                                 retryWait: float = None,
                                                 timeout: float = None,
-                                                numInstances: int = None):
-    coro = eventually(instances, nodes, numInstances,
+                                                instances_list: Sequence[int] = None):
+    coro = eventually(instances, nodes, instances_list,
                       retryWait=retryWait, timeout=timeout)
     insts, timeConsumed = timeThis(looper.run, coro)
     newTimeout = timeout - timeConsumed if timeout is not None else None
@@ -847,14 +847,14 @@ def checkProtocolInstanceSetup(looper: Looper,
                                nodes: Sequence[TestNode],
                                retryWait: float = 1,
                                customTimeout: float = None,
-                               numInstances: int = None):
+                               instances: Sequence[int] = None):
     timeout = customTimeout or waits.expectedPoolElectionTimeout(len(nodes))
 
     checkEveryProtocolInstanceHasOnlyOnePrimary(looper=looper,
                                                 nodes=nodes,
                                                 retryWait=retryWait,
                                                 timeout=timeout,
-                                                numInstances=numInstances)
+                                                instances_list=instances)
 
     checkEveryNodeHasAtMostOnePrimary(looper=looper,
                                       nodes=nodes,
@@ -872,7 +872,7 @@ def ensureElectionsDone(looper: Looper,
                         nodes: Sequence[TestNode],
                         retryWait: float = None,  # seconds
                         customTimeout: float = None,
-                        numInstances: int = None) -> Sequence[TestNode]:
+                        instances_list: Sequence[int] = None) -> Sequence[TestNode]:
     # TODO: Change the name to something like `ensure_primaries_selected`
     # since there might not always be an election, there might be a round
     # robin selection
@@ -881,7 +881,7 @@ def ensureElectionsDone(looper: Looper,
 
     :param retryWait:
     :param customTimeout: specific timeout
-    :param numInstances: expected number of protocol instances
+    :param instances_list: expected number of protocol instances
     :return: primary replica for each protocol instance
     """
 
@@ -896,7 +896,7 @@ def ensureElectionsDone(looper: Looper,
         nodes=nodes,
         retryWait=retryWait,
         customTimeout=customTimeout,
-        numInstances=numInstances)
+        instances=instances_list)
 
 
 def genNodeReg(count=None, names=None) -> Dict[str, NodeDetail]:
@@ -953,12 +953,12 @@ def timeThis(func, *args, **kwargs):
 
 
 def instances(nodes: Sequence[Node],
-              numInstances: int = None) -> Dict[int, List[replica.Replica]]:
-    numInstances = (getRequiredInstances(len(nodes))
-                    if numInstances is None else numInstances)
+              instances: Sequence[int] = None) -> Dict[int, List[replica.Replica]]:
+    instances = (range(getRequiredInstances(len(nodes)))
+                 if instances is None else instances)
     for n in nodes:
-        assert len(n.replicas) == numInstances
-    return {i: [n.replicas[i] for n in nodes] for i in range(numInstances)}
+        assert len(n.replicas) == len(instances)
+    return {i: [n.replicas[i] for n in nodes] for i in instances}
 
 
 def getRequiredInstances(nodeCount: int) -> int:

--- a/plenum/test/test_node_connection.py
+++ b/plenum/test/test_node_connection.py
@@ -55,7 +55,7 @@ def testNodesConnectsWhenOneNodeIsLate(allPluginsPath, tdir_for_func, tconf_for_
     looper.run(checkNodesConnected(nodes[:3]))
 
     # wait for the election to complete with the first three nodes
-    ensureElectionsDone(looper, nodes[:3], numInstances=2)
+    ensureElectionsDone(looper, nodes[:3], instances_list=range(2))
 
     # start the fourth and see that it learns who the primaries are
     # from the other nodes

--- a/plenum/test/view_change/conftest.py
+++ b/plenum/test/view_change/conftest.py
@@ -9,6 +9,7 @@ from plenum.server.quorums import Quorums
 from plenum.server.view_change.view_changer import ViewChanger
 from plenum.test.conftest import getValueFromModule
 from plenum.test.primary_selection.test_primary_selector import FakeNode
+from plenum.test.test_node import getRequiredInstances
 from plenum.test.testing_utils import FakeSomething
 
 
@@ -35,6 +36,7 @@ def perf_chk_patched(tconf, request):
 
 @pytest.fixture(scope='function', params=[0, 10])
 def fake_view_changer(request, tconf):
+    node_count = 4
     node_stack = FakeSomething(
         name="fake stack",
         connecteds={"Alpha", "Beta", "Gamma", "Delta"},
@@ -47,14 +49,15 @@ def fake_view_changer(request, tconf):
     node = FakeSomething(
         name="SomeNode",
         viewNo=request.param,
-        quorums=Quorums(getValueFromModule(request, 'nodeCount', default=4)),
+        quorums=Quorums(getValueFromModule(request, 'nodeCount', default=node_count)),
         nodestack=node_stack,
         utc_epoch=lambda *args: get_utc_epoch(),
         config=tconf,
         monitor=monitor,
         discard=lambda a, b, c: print(b),
-        lost_primary_at=None,
-        master_primary_name='Alpha'
+        primaries_disconnection_times=[None] * getRequiredInstances(node_count),
+        master_primary_name='Alpha',
+        master_replica=FakeSomething(instId=0)
     )
     view_changer = ViewChanger(node)
     return view_changer

--- a/plenum/test/view_change/test_diconnected_node_reconnects_after_view_change.py
+++ b/plenum/test/view_change/test_diconnected_node_reconnects_after_view_change.py
@@ -56,7 +56,7 @@ def test_disconnected_node_with_lagged_view_pulls_up_its_view_on_reconnection(
 
     ensure_view_change(looper, other_nodes)
     ensureElectionsDone(looper, other_nodes,
-                        numInstances=getRequiredInstances(len(txnPoolNodeSet)))
+                        instances_list=range(getRequiredInstances(len(txnPoolNodeSet))))
     ensure_all_nodes_have_same_data(looper, other_nodes)
     checkViewNoForNodes(other_nodes, 2)
     checkViewNoForNodes([lagged_node], 1)
@@ -66,7 +66,7 @@ def test_disconnected_node_with_lagged_view_pulls_up_its_view_on_reconnection(
 
     ensure_view_change(looper, other_nodes)
     ensureElectionsDone(looper, other_nodes,
-                        numInstances=getRequiredInstances(len(txnPoolNodeSet)))
+                        instances_list=range(getRequiredInstances(len(txnPoolNodeSet))))
     ensure_all_nodes_have_same_data(looper, other_nodes)
     checkViewNoForNodes(other_nodes, 3)
     checkViewNoForNodes([lagged_node], 1)

--- a/plenum/test/view_change/test_if_primary_disconnected.py
+++ b/plenum/test/view_change/test_if_primary_disconnected.py
@@ -9,24 +9,24 @@ def fake_view_changer(fake_view_changer):
 
 
 def test_is_primary_disconnected_lost_none(fake_view_changer):
-    fake_view_changer.node.lost_primary_at = None
+    fake_view_changer.node.primaries_disconnection_times[0] = None
     assert not fake_view_changer.is_primary_disconnected()
 
 
 def test_is_primary_disconnected_primary_none(fake_view_changer):
-    fake_view_changer.node.lost_primary_at = time.perf_counter()
+    fake_view_changer.node.primaries_disconnection_times[0] = time.perf_counter()
     fake_view_changer.node.master_primary_name = None
     assert not fake_view_changer.is_primary_disconnected()
 
 
 def test_is_primary_disconnected_primary_absent(fake_view_changer):
-    fake_view_changer.node.lost_primary_at = time.perf_counter()
+    fake_view_changer.node.primaries_disconnection_times[0] = time.perf_counter()
     fake_view_changer.node.master_primary_name = 'Alpha'
     assert not fake_view_changer.is_primary_disconnected()
 
 
 def test_is_primary_disconnected(fake_view_changer):
-    fake_view_changer.node.lost_primary_at = time.perf_counter()
+    fake_view_changer.node.primaries_disconnection_times[0] = time.perf_counter()
     fake_view_changer.node.master_primary_name = 'Alpha'
     fake_view_changer.node.nodestack.conns.remove('Alpha')
     assert fake_view_changer.is_primary_disconnected()

--- a/plenum/test/view_change/test_instance_change_if_needed.py
+++ b/plenum/test/view_change/test_instance_change_if_needed.py
@@ -21,7 +21,7 @@ def fake_view_changer(fake_view_changer):
 
 def test_instance_change_on_primary_disconnected(looper, fake_view_changer, tconf):
     # Primary was disconnected
-    fake_view_changer.node.lost_primary_at = time.perf_counter()
+    fake_view_changer.node.primaries_disconnection_times[0] = time.perf_counter()
     fake_view_changer.node.nodestack.conns.remove('Alpha')
     fake_view_changer.on_primary_loss()
 
@@ -38,7 +38,7 @@ def test_instance_change_on_primary_disconnected(looper, fake_view_changer, tcon
     assert fake_view_changer.instance_change_rounds == times
 
     # Primary connected
-    fake_view_changer.node.lost_primary_at = None
+    fake_view_changer.node.primaries_disconnection_times[0] = None
     fake_view_changer.node.nodestack.conns.add('Alpha')
 
     for _ in range(times):

--- a/plenum/test/view_change/test_no_future_view_change_while_catchup.py
+++ b/plenum/test/view_change/test_no_future_view_change_while_catchup.py
@@ -50,7 +50,7 @@ def test_no_propagated_future_view_change_until_synced(txnPoolNodeSet, looper, m
     with delay_rules(lagged_node.nodeIbStasher, icDelay()):
         # make sure that View Change happened on all nodes but the lagging one
         ensure_view_change(looper, other_nodes)
-        checkProtocolInstanceSetup(looper=looper, nodes=other_nodes, numInstances=2)
+        checkProtocolInstanceSetup(looper=looper, nodes=other_nodes, instances=range(2))
         ensure_all_nodes_have_same_data(looper, nodes=other_nodes)
 
         check_no_view_change(looper, lagged_node)

--- a/plenum/test/view_change/test_no_future_view_change_while_view_change.py
+++ b/plenum/test/view_change/test_no_future_view_change_while_view_change.py
@@ -23,7 +23,7 @@ def test_no_propagated_future_view_change_while_view_change(txnPoolNodeSet, loop
     with delay_rules(lagged_node.nodeIbStasher, icDelay()):
         # make sure that View Change happened on all nodes but the lagging one
         ensure_view_change(looper, other_nodes)
-        checkProtocolInstanceSetup(looper=looper, nodes=other_nodes, numInstances=2)
+        checkProtocolInstanceSetup(looper=looper, nodes=other_nodes, instances=range(2))
         ensure_all_nodes_have_same_data(looper, nodes=other_nodes)
 
         # check that lagged node recived 3 Future VCD, but didn't start new view change

--- a/plenum/test/view_change/test_view_change_n_minus_f_quorum.py
+++ b/plenum/test/view_change/test_view_change_n_minus_f_quorum.py
@@ -23,7 +23,7 @@ def test_view_change_n_minus_f_quorum(txnPoolNodeSet, looper):
     # Check that view changes
     ensure_view_change(looper, active)
     ensureElectionsDone(looper=looper, nodes=active,
-                        numInstances=2, customTimeout=60)
+                        instances_list=range(2), customTimeout=60)
     ensure_all_nodes_have_same_data(looper, nodes=active)
 
     # Switching another node off to make sure that this time the quorum is not

--- a/plenum/test/view_change/test_view_change_start_without_primary.py
+++ b/plenum/test/view_change/test_view_change_start_without_primary.py
@@ -20,7 +20,7 @@ def test_view_change_without_primary(txnPoolNodeSet, looper,
 
     checkProtocolInstanceSetup(looper=looper, nodes=txnPoolNodeSet, retryWait=1,
                                customTimeout=timeout,
-                               numInstances=getRequiredInstances(len(txnPoolNodeSet)))
+                               instances=range(getRequiredInstances(len(txnPoolNodeSet))))
 
 
 def stop_nodes_and_remove_first(looper, nodes):

--- a/plenum/test/view_change/test_view_change_timeout.py
+++ b/plenum/test/view_change/test_view_change_timeout.py
@@ -164,7 +164,7 @@ def test_view_change_restarted_by_timeout_if_next_primary_disconnected(
 
     alive_nodes = stop_next_primary(txnPoolNodeSet)
 
-    ensureElectionsDone(looper=looper, nodes=alive_nodes, numInstances=3)
+    ensureElectionsDone(looper=looper, nodes=alive_nodes, instances_list=range(3))
 
     # There were 2 view changes
     for node in alive_nodes:

--- a/plenum/test/view_change_with_delays/test_delayed_instance_changes.py
+++ b/plenum/test/view_change_with_delays/test_delayed_instance_changes.py
@@ -45,7 +45,7 @@ def test_delayed_instance_changes_after_vcd_for_next_view(looper, txnPoolNodeSet
         waitForViewChange(looper, nodes, expectedViewNo=1)
 
         # make sure view change is finished on all nodes except the slow one
-        ensureElectionsDone(looper, fast_nodes, numInstances=3)
+        ensureElectionsDone(looper, fast_nodes, instances_list=range(3))
 
         # drop all VCD to view=1
         slow_stasher.drop_delayeds()
@@ -63,7 +63,7 @@ def test_delayed_instance_changes_after_vcd_for_next_view(looper, txnPoolNodeSet
         waitForViewChange(looper, fast_nodes, expectedViewNo=2)
 
         # make sure view change is finished on all nodes except the slow one
-        ensureElectionsDone(looper, fast_nodes, numInstances=3)
+        ensureElectionsDone(looper, fast_nodes, instances_list=range(3))
 
         # slow node is still on view=1
         assert slow_node.viewNo == 1


### PR DESCRIPTION
When changing the number of connected nodes, a node schedules `propose_replica_remove()` to test the connection after `config.TolerateBackupPrimaryDisconnection` seconds.
The check will be performed `config.TimePrimaryBackupDisconnection` times, if all this time the backup primary node  was disconnected, its replica will be removed. 