### PR TITLE
INDY-1700: Removing rejected reqs from Propagator

### DIFF
--- a/plenum/test/checkpoints/helper.py
+++ b/plenum/test/checkpoints/helper.py
@@ -13,10 +13,10 @@ def chkChkpoints(nodes, total: int, stableIndex: int = None):
                     assert not state.isStable
 
 
-def checkRequestCounts(nodes, req_count, cons_count, batches_count):
+def checkRequestCounts(nodes, req_count, batches_count):
     for node in nodes:
         assertEquality(len(node.requests), req_count)
         for r in node.replicas.values():
-            assertEquality(len(r.commits), cons_count)
-            assertEquality(len(r.prepares), cons_count)
+            assertEquality(len(r.commits), batches_count)
+            assertEquality(len(r.prepares), batches_count)
             assertEquality(len(r.batches), batches_count)

--- a/plenum/test/checkpoints/test_view_change_after_checkpoint.py
+++ b/plenum/test/checkpoints/test_view_change_after_checkpoint.py
@@ -37,7 +37,7 @@ def test_checkpoint_across_views(sent_batches, chkFreqPatched, looper, txnPoolNo
     # Check that correct garbage collection happens
     non_gced_batch_count = (sent_batches - CHK_FREQ) if sent_batches >= CHK_FREQ else sent_batches
     looper.run(eventually(checkRequestCounts, txnPoolNodeSet, batch_size * non_gced_batch_count,
-                          non_gced_batch_count, non_gced_batch_count, retryWait=1))
+                          non_gced_batch_count, retryWait=1))
 
     ensure_view_change(looper, txnPoolNodeSet)
     ensureElectionsDone(looper=looper, nodes=txnPoolNodeSet)
@@ -54,14 +54,14 @@ def test_checkpoint_across_views(sent_batches, chkFreqPatched, looper, txnPoolNo
             assert r.h == 0
             assert r.H == r._h + chkFreqPatched.LOG_SIZE
 
-    checkRequestCounts(txnPoolNodeSet, 0, 0, 0)
+    checkRequestCounts(txnPoolNodeSet, 0, 0)
 
     # Even after view change, chekpointing works
     sdk_send_batches_of_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle, sdk_wallet_client,
                                          batch_size * sent_batches, sent_batches)
 
     looper.run(eventually(checkRequestCounts, txnPoolNodeSet, batch_size * non_gced_batch_count,
-                          non_gced_batch_count, non_gced_batch_count, retryWait=1))
+                          non_gced_batch_count, retryWait=1))
 
     # Send more batches so one more checkpoint happens. This is done so that
     # when this test finishes, all requests are garbage collected and the
@@ -69,4 +69,4 @@ def test_checkpoint_across_views(sent_batches, chkFreqPatched, looper, txnPoolNo
     more = CHK_FREQ - non_gced_batch_count
     sdk_send_batches_of_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle, sdk_wallet_client,
                                          batch_size * more, more)
-    looper.run(eventually(checkRequestCounts, txnPoolNodeSet, 0, 0, 0, retryWait=1))
+    looper.run(eventually(checkRequestCounts, txnPoolNodeSet, 0, 0, retryWait=1))


### PR DESCRIPTION
- Modified the test verifying requests removal from Propagator.requests collection on checkpoint stabilization: now removal of rejected requests is also verified.
- Corrected a related test helper-function and tests using it.
- Fixed a bug with lack of removing rejected requests from Propagator.requests collection.