### PR TITLE
INDY-1739: Unit tests for ability to start catchup

### DIFF
--- a/plenum/test/node_catchup/test_catchup_start.py
+++ b/plenum/test/node_catchup/test_catchup_start.py
@@ -25,7 +25,7 @@ def node(_patched_node):
     return _patched_node
 
 
-@pytest.mark.parametrize('mode, must_started', [
+@pytest.mark.parametrize('mode, catchup_must_start', [
     (Mode.starting, False),
     (Mode.discovering, False),
     (Mode.discovered, False),
@@ -33,10 +33,10 @@ def node(_patched_node):
     (Mode.synced, True),
     (Mode.participating, True),
 ])
-def test_catchup_ability_in_given_mode(node, mode, must_started):
+def test_catchup_ability_in_given_mode(node, mode, catchup_must_start):
     node.mode = mode
     node.start_catchup()
-    assert catchup_started is must_started
+    assert catchup_started is catchup_must_start
 
 
 def test_catchup_can_be_started_with_just_started_flag_when_mode_not_set(node):

--- a/plenum/test/node_catchup/test_catchup_start.py
+++ b/plenum/test/node_catchup/test_catchup_start.py
@@ -21,7 +21,22 @@ def _patched_node(txnPoolNodeSet):
 def node(_patched_node):
     global catchup_started
     catchup_started = False
+    node.mode = Mode.participating
     return _patched_node
+
+
+@pytest.mark.parametrize('mode, must_started', [
+    (Mode.starting, False),
+    (Mode.discovering, False),
+    (Mode.discovered, False),
+    (Mode.syncing, False),
+    (Mode.synced, True),
+    (Mode.participating, True),
+])
+def test_catchup_ability_in_given_mode(node, mode, must_started):
+    node.mode = mode
+    node.start_catchup()
+    assert catchup_started is must_started
 
 
 def test_catchup_can_be_started_with_just_started_flag_when_mode_not_set(node):
@@ -35,39 +50,3 @@ def test_catchup_cannot_be_started_without_just_started_flag_when_mode_not_set(
     node.mode = None
     node.start_catchup()
     assert not catchup_started
-
-
-def test_catchup_cannot_be_started_in_starting_mode(node):
-    node.mode = Mode.starting
-    node.start_catchup()
-    assert not catchup_started
-
-
-def test_catchup_cannot_be_started_in_discovering_mode(node):
-    node.mode = Mode.discovering
-    node.start_catchup()
-    assert not catchup_started
-
-
-def test_catchup_cannot_be_started_in_discovered_mode(node):
-    node.mode = Mode.discovered
-    node.start_catchup()
-    assert not catchup_started
-
-
-def test_catchup_cannot_be_started_in_syncing_mode(node):
-    node.mode = Mode.syncing
-    node.start_catchup()
-    assert not catchup_started
-
-
-def test_catchup_can_be_started_in_synced_mode(node):
-    node.mode = Mode.synced
-    node.start_catchup()
-    assert catchup_started
-
-
-def test_catchup_can_be_started_in_participating_mode(node):
-    node.mode = Mode.participating
-    node.start_catchup()
-    assert catchup_started

--- a/plenum/test/node_catchup/test_catchup_start.py
+++ b/plenum/test/node_catchup/test_catchup_start.py
@@ -1,0 +1,73 @@
+import pytest
+
+from plenum.common.startable import Mode
+
+catchup_started = False
+
+
+def _mocked_do_start_catchup(just_started):
+    global catchup_started
+    catchup_started = True
+
+
+@pytest.fixture(scope='module')
+def _patched_node(txnPoolNodeSet):
+    node = txnPoolNodeSet[0]
+    node._do_start_catchup = _mocked_do_start_catchup
+    return node
+
+
+@pytest.fixture(scope='function')
+def node(_patched_node):
+    global catchup_started
+    catchup_started = False
+    return _patched_node
+
+
+def test_catchup_can_be_started_with_just_started_flag_when_mode_not_set(node):
+    node.mode = None
+    node.start_catchup(just_started=True)
+    assert catchup_started
+
+
+def test_catchup_cannot_be_started_without_just_started_flag_when_mode_not_set(
+        node):
+    node.mode = None
+    node.start_catchup()
+    assert not catchup_started
+
+
+def test_catchup_cannot_be_started_in_starting_mode(node):
+    node.mode = Mode.starting
+    node.start_catchup()
+    assert not catchup_started
+
+
+def test_catchup_cannot_be_started_in_discovering_mode(node):
+    node.mode = Mode.discovering
+    node.start_catchup()
+    assert not catchup_started
+
+
+def test_catchup_cannot_be_started_in_discovered_mode(node):
+    node.mode = Mode.discovered
+    node.start_catchup()
+    assert not catchup_started
+
+
+def test_catchup_cannot_be_started_in_syncing_mode(node):
+    node.mode = Mode.syncing
+    node.start_catchup()
+    assert not catchup_started
+
+
+def test_catchup_can_be_started_in_synced_mode(node):
+    node.mode = Mode.synced
+    node.start_catchup()
+    assert catchup_started
+
+
+def test_catchup_can_be_started_in_participating_mode(node):
+    node.mode = Mode.participating
+    node.start_catchup()
+    assert catchup_started

--- a/plenum/test/node_catchup/test_node_catchup_after_checkpoints.py
+++ b/plenum/test/node_catchup/test_node_catchup_after_checkpoints.py
@@ -11,9 +11,6 @@ from plenum.test.node_catchup.helper import waitNodeDataInequality, waitNodeData
 
 logger = getLogger()
 
-TestRunningTimeLimitSec = 200
-
-
 CHK_FREQ = 5
 LOG_SIZE = 3 * CHK_FREQ
 

--- a/plenum/test/test_node.py
+++ b/plenum/test/test_node.py
@@ -462,6 +462,7 @@ replica_spyables = [
     replica.Replica.processPrePrepare,
     replica.Replica.processPrepare,
     replica.Replica.processCommit,
+    replica.Replica.processCheckpoint,
     replica.Replica.doPrepare,
     replica.Replica.doOrder,
     replica.Replica.discard,


### PR DESCRIPTION
- Added unit tests verifying ability to start catchup in different node modes.
- Reduced execution time of the integration test verifying that a catchup cannot be started if another catchup is in progress.
- Removed a not needed execution time limit override from an existing test.