### PR TITLE
INDY-1753: Eliminated request schema re-validation

### DIFF
--- a/plenum/server/message_handlers.py
+++ b/plenum/server/message_handlers.py
@@ -4,6 +4,7 @@ from abc import ABCMeta, abstractmethod
 from plenum.common.exceptions import MismatchedMessageReplyException
 from plenum.common.messages.node_messages import MessageReq, MessageRep, \
     LedgerStatus, PrePrepare, ConsistencyProof, Propagate, Prepare, Commit
+from plenum.common.txn_util import TxnUtilConfig
 from plenum.common.types import f
 from plenum.server import replica
 from stp_core.common.log import getlogger
@@ -229,7 +230,7 @@ class PropagateHandler(BaseHandler):
 
     def create(self, msg: Dict, **kwargs) -> Propagate:
         ppg = Propagate(**msg)
-        request = self.node.client_request_class(**ppg.request)
+        request = TxnUtilConfig.client_request_class(**ppg.request)
         if request.digest != kwargs['digest']:
             raise MismatchedMessageReplyException
         return ppg

--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -70,7 +70,7 @@ from plenum.common.stacks import nodeStackClass, clientStackClass
 from plenum.common.startable import Status, Mode
 from plenum.common.txn_util import idr_from_req_data, get_req_id, \
     get_seq_no, get_type, get_payload_data, \
-    get_txn_time, get_digest
+    get_txn_time, get_digest, TxnUtilConfig
 from plenum.common.types import PLUGIN_TYPE_VERIFICATION, \
     PLUGIN_TYPE_PROCESSING, OPERATION, f
 from plenum.common.util import friendlyEx, getMaxFailures, pop_keys, \
@@ -1842,7 +1842,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         """
         msg, frm = wrappedMsg
         if self.isClientBlacklisted(frm):
-            self.discard(msg[:256], "received from blacklisted client {}".format(frm), logger.display)
+            self.discard(str(msg)[:256], "received from blacklisted client {}".format(frm), logger.display)
             return None
 
         needStaticValidation = False
@@ -2384,9 +2384,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         logger.debug("{} received propagated request: {}".
                      format(self.name, msg))
 
-        # ToDo: During verifySignature procedure was already created request object.
-        # Need to avoid request object recreating
-        request = self.client_request_class(**msg.request)
+        request = TxnUtilConfig.client_request_class(**msg.request)
 
         clientName = msg.senderClient
 
@@ -3057,7 +3055,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
             return
         if isinstance(msg, Propagate):
             typ = 'propagate'
-            req = self.client_request_class(**msg.request)
+            req = TxnUtilConfig.client_request_class(**msg.request)
         else:
             typ = ''
             req = msg

--- a/plenum/test/node_request/test_request_schema_validation.py
+++ b/plenum/test/node_request/test_request_schema_validation.py
@@ -1,0 +1,105 @@
+import time
+
+import pytest
+
+from plenum.common.constants import CURRENT_PROTOCOL_VERSION, OP_FIELD_NAME, \
+    PROPAGATE
+from plenum.common.messages.client_request import ClientMessageValidator
+from plenum.common.messages.node_messages import Propagate
+from plenum.common.request import Request
+from plenum.common.signer_did import DidSigner
+from plenum.common.types import OPERATION, f
+
+CLIENT_PUBLIC_KEY = b'M2Qw^f:=4VU*+xmMF^Tk4N&Y0z)5<5SPt.{h}SE{'
+
+
+original_validate = ClientMessageValidator.validate
+
+
+@pytest.fixture(scope="module")
+def validation_patched():
+    """
+    Patches request schema validation
+    """
+    ClientMessageValidator.validate = patched_validate
+    yield
+    ClientMessageValidator.validate = original_validate
+
+
+@pytest.fixture(scope="function")
+def req(poolTxnClientData):
+    _, seed = poolTxnClientData
+    signer = DidSigner(seed=seed)
+
+    request = {
+        f.IDENTIFIER.nm: signer.identifier,
+        f.REQ_ID.nm: int(time.time() * 10 ** 6),
+        OPERATION: {
+            'amount': 62,
+            'type': 'buy'
+        },
+        f.PROTOCOL_VERSION.nm: CURRENT_PROTOCOL_VERSION
+    }
+
+    request[f.SIG.nm] = signer.sign(request)
+
+    return request
+
+
+@pytest.fixture(scope="function")
+def propagate(req):
+    ppg = {
+        OP_FIELD_NAME: PROPAGATE,
+        f.REQUEST.nm: req,
+        f.SENDER_CLIENT.nm: CLIENT_PUBLIC_KEY.decode()
+    }
+
+    return ppg
+
+
+validation_times = 0
+
+
+def patched_validate(self, dct):
+    global validation_times
+    validation_times += 1
+    original_validate(self, dct)
+
+
+def test_schema_validation_for_request_from_client(validation_patched,
+                                                   txnPoolNodeSet, req):
+    node = txnPoolNodeSet[0]
+
+    validation_times_before = validation_times
+    node.handleOneClientMsg((req, CLIENT_PUBLIC_KEY))
+    msg, frm = node.clientInBox.pop()  # pop the last added message
+    assert isinstance(msg, Request)
+    assert frm == CLIENT_PUBLIC_KEY
+    node.processRequest(msg, frm)
+    validation_times_after = validation_times
+
+    # The request schema must be validated 2 times: the first time when
+    # a SafeRequest instance is constructed for the incoming request from
+    # a client and the second time when a Propagate instance is constructed
+    # for propagating the request
+    assert validation_times_after - validation_times_before == 2
+
+
+def test_request_schema_validation_for_propagate(validation_patched,
+                                                 txnPoolNodeSet, propagate):
+    node = txnPoolNodeSet[0]
+    other_node = txnPoolNodeSet[1]
+
+    validation_times_before = validation_times
+    node.handleOneNodeMsg((propagate, other_node.name))
+    msg, frm = node.nodeInBox.pop()  # pop the last added message
+    assert isinstance(msg, Propagate)
+    assert frm == other_node.name
+    node.processPropagate(msg, frm)
+    validation_times_after = validation_times
+
+    # The request schema must be validated 2 times: the first time when
+    # a Propagate instance is constructed for the incoming request propagated
+    # by another node and the second time when a Propagate instance is
+    # constructed for propagating the request
+    assert validation_times_after - validation_times_before == 2


### PR DESCRIPTION
- Eliminated repeated validations of a write request against the schema on handling of one Propagate message and on handling one MessageRep with Propagate.
- Added tests verifying the count of request schema validation times on handling a write request from a client and on handling Propagate.
- Corrected limitation of the length of a log message in `Node.validateClientMsg` method.