### PR TITLE
Fixes for Python 3.6 support

### DIFF
--- a/state/util/utils.py
+++ b/state/util/utils.py
@@ -1,11 +1,15 @@
 import os
 import string
 
-import sha3 as _sha3
 
-
-def sha3_256(x):
-    return _sha3.sha3_256(x).digest()
+import hashlib
+if hasattr(hashlib, 'sha3_256'):
+    def sha3_256(x):
+        return hashlib.sha3_256(x).digest()
+else:
+    import sha3 as _sha3
+    def sha3_256(x):
+        return _sha3.sha3_256(x).digest()
 
 
 import rlp

--- a/storage/kv_store_file.py
+++ b/storage/kv_store_file.py
@@ -152,7 +152,7 @@ class KeyValueStorageFile(KeyValueStorage):
 
     @abstractmethod
     def _parse_line(self, line, prefix=None, returnKey: bool=True,
-                    returnValue: bool=True, key=None) -> Tuple[Optional[str], Optional[str]]:
+                    returnValue: bool=True, key=None):
         pass
 
     @abstractmethod

--- a/storage/kv_store_file.py
+++ b/storage/kv_store_file.py
@@ -152,7 +152,7 @@ class KeyValueStorageFile(KeyValueStorage):
 
     @abstractmethod
     def _parse_line(self, line, prefix=None, returnKey: bool=True,
-                    returnValue: bool=True, key=None) -> Tuple[Optional, Optional]:
+                    returnValue: bool=True, key=None) -> Tuple[Optional[str], Optional[str]]:
         pass
 
     @abstractmethod


### PR DESCRIPTION
- Prefer hashlib.sha3_256 when it's available (in python 3.6+) - the sha3 module is not compatible

- Fix a type checking error that occurs in python 3.6+

This is an update of PR #714 