### PR TITLE
INDY-1795: Resume ordering on backup replica

### DIFF
--- a/plenum/server/replica.py
+++ b/plenum/server/replica.py
@@ -1888,14 +1888,24 @@ class Replica(HasActionQueue, MessageProcessor, HookManager):
         if not is_stashed_enough:
             return
 
-        self.logger.display('{} has lagged for {} checkpoints so updating watermarks to {}'.
-                            format(self, lag_in_checkpoints, stashed_checkpoint_ends[-1]))
-        self.h = stashed_checkpoint_ends[-1]
-
-        if self.isMaster and not self.isPrimary:
-            self.logger.display('{} has lagged for {} checkpoints so the catchup procedure starts'.
-                                format(self, lag_in_checkpoints))
-            self.node.start_catchup()
+        if self.isMaster:
+            self.logger.display(
+                '{} has lagged for {} checkpoints so updating watermarks to {}'.
+                format(self, lag_in_checkpoints, stashed_checkpoint_ends[-1]))
+            self.h = stashed_checkpoint_ends[-1]
+            if not self.isPrimary:
+                self.logger.display(
+                    '{} has lagged for {} checkpoints so the catchup procedure starts'.
+                    format(self, lag_in_checkpoints))
+                self.node.start_catchup()
+        else:
+            self.logger.info(
+                '{} has lagged for {} checkpoints so adjust last_ordered_3pc to {}, '
+                'shift watermarks and clean collections'.
+                format(self, lag_in_checkpoints, stashed_checkpoint_ends[-1]))
+            # The following call will adjust last_ordered_3pc,
+            # shift watermarks and clean collections
+            self.caught_up_till_3pc((self.viewNo, stashed_checkpoint_ends[-1]))
 
     def addToCheckpoint(self, ppSeqNo, digest, ledger_id, view_no):
         for (s, e) in self.checkpoints.keys():

--- a/plenum/server/replica.py
+++ b/plenum/server/replica.py
@@ -1903,9 +1903,11 @@ class Replica(HasActionQueue, MessageProcessor, HookManager):
                 '{} has lagged for {} checkpoints so adjust last_ordered_3pc to {}, '
                 'shift watermarks and clean collections'.
                 format(self, lag_in_checkpoints, stashed_checkpoint_ends[-1]))
-            # The following call will adjust last_ordered_3pc,
-            # shift watermarks and clean collections
+            # Adjust last_ordered_3pc, shift watermarks, clean operational
+            # collections and process stashed messages which now fit between
+            # watermarks
             self.caught_up_till_3pc((self.viewNo, stashed_checkpoint_ends[-1]))
+            self.processStashedMsgsForNewWaterMarks()
 
     def addToCheckpoint(self, ppSeqNo, digest, ledger_id, view_no):
         for (s, e) in self.checkpoints.keys():

--- a/plenum/test/checkpoints/test_backup_replica_resumes_ordering_on_lag_in_checkpoints.py
+++ b/plenum/test/checkpoints/test_backup_replica_resumes_ordering_on_lag_in_checkpoints.py
@@ -1,13 +1,8 @@
-import pytest
-
 from plenum.common.constants import DOMAIN_LEDGER_ID
 from plenum.server.replica import Replica
 from plenum.test import waits
-from plenum.test.delayers import cDelay
+from plenum.test.delayers import cDelay, chk_delay
 from plenum.test.helper import sdk_send_random_requests, assertExp
-from plenum.test.test_node import getNonPrimaryReplicas, getPrimaryReplica, \
-    ensureElectionsDone
-from plenum.test.view_change.helper import ensure_view_change
 from stp_core.loop.eventually import eventually
 
 nodeCount = 4
@@ -16,32 +11,10 @@ CHK_FREQ = 5
 LOG_SIZE = 3 * CHK_FREQ
 
 
-@pytest.fixture(scope='function')
-def view_change_done(looper, txnPoolNodeSet):
-    ensure_view_change(looper, txnPoolNodeSet)
-    ensureElectionsDone(looper=looper, nodes=txnPoolNodeSet)
-
-
-@pytest.fixture(scope='function',
-                params=['primary', 'non-primary'])
-def one_replica_and_others_in_backup_instance(
-        request, txnPoolNodeSet, view_change_done):
-
-    backup_inst_id = 1
-
-    primary = getPrimaryReplica(txnPoolNodeSet, backup_inst_id)
-    non_primaries = getNonPrimaryReplicas(txnPoolNodeSet, backup_inst_id)
-
-    if request.param == 'primary':
-        return primary, non_primaries
-    else:
-        return non_primaries[0], [primary] + non_primaries[1:]
-
-
 def test_backup_replica_resumes_ordering_on_lag_in_checkpoints(
         looper, chkFreqPatched, reqs_for_checkpoint,
-        sdk_pool_handle, sdk_wallet_client,
-        one_replica_and_others_in_backup_instance):
+        one_replica_and_others_in_backup_instance,
+        sdk_pool_handle, sdk_wallet_client, view_change_done):
     """
     Verifies resumption of ordering 3PC-batches on a backup replica
     on detection of a lag in checkpoints
@@ -50,10 +23,9 @@ def test_backup_replica_resumes_ordering_on_lag_in_checkpoints(
     slow_replica, other_replicas = one_replica_and_others_in_backup_instance
     view_no = slow_replica.viewNo
 
-    # Send a request
+    # Send a request and ensure that the replica orders the batch for it
     sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client, 1)
 
-    # Ensure that the backup replica has ordered the batch for it
     looper.run(
         eventually(lambda: assertExp(slow_replica.last_ordered_3pc == (view_no, 1)),
                    retryWait=1,
@@ -68,10 +40,10 @@ def test_backup_replica_resumes_ordering_on_lag_in_checkpoints(
     # Send a request for which the replica will not be able to order the batch
     # due to an insufficient count of Commits
     sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client, 1)
-
     looper.runFor(waits.expectedTransactionExecutionTime(4))
 
     # Recover reception of Commits
+    slow_replica.node.nodeIbStasher.drop_delayeds()
     slow_replica.node.nodeIbStasher.resetDelays()
 
     # Send requests but in a quantity insufficient
@@ -79,9 +51,10 @@ def test_backup_replica_resumes_ordering_on_lag_in_checkpoints(
     sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client,
                              Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP *
                              reqs_for_checkpoint - 2)
-
-    # Ensure that the replica has not ordered the batches
     looper.runFor(waits.expectedTransactionExecutionTime(4))
+
+    # Ensure that the replica has not ordered any batches
+    # after the very first one
     assert slow_replica.last_ordered_3pc == (view_no, 1)
 
     # Ensure that the watermarks have not been shifted since the view start
@@ -135,12 +108,104 @@ def test_backup_replica_resumes_ordering_on_lag_in_checkpoints(
     # Ensure that now there are no quorumed stashed checkpoints
     assert not slow_replica.stashed_checkpoints_with_quorum()
 
-    # Send a request
+    # Send a request and ensure that the replica orders the batch for it
     sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client, 1)
 
-    # Ensure that the replica has ordered the batch for the sent request
     looper.run(
         eventually(lambda: assertExp(slow_replica.last_ordered_3pc ==
                                      (view_no, (Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP + 1) * CHK_FREQ + 1)),
+                   retryWait=1,
+                   timeout=waits.expectedTransactionExecutionTime(4)))
+
+
+def test_backup_replica_resumes_ordering_on_lag_if_checkpoints_belate(
+        looper, chkFreqPatched, reqs_for_checkpoint,
+        one_replica_and_others_in_backup_instance,
+        sdk_pool_handle, sdk_wallet_client, view_change_done):
+    """
+    Verifies resumption of ordering 3PC-batches on a backup replica
+    on detection of a lag in checkpoints in case it is detected after
+    some batch in the next checkpoint has already been committed but cannot
+    be ordered out of turn
+    """
+
+    slow_replica, other_replicas = one_replica_and_others_in_backup_instance
+    view_no = slow_replica.viewNo
+
+    # Send a request and ensure that the replica orders the batch for it
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client, 1)
+
+    looper.run(
+        eventually(lambda: assertExp(slow_replica.last_ordered_3pc == (view_no, 1)),
+                   retryWait=1,
+                   timeout=waits.expectedTransactionExecutionTime(4)))
+
+    # Don't receive Commits from two replicas
+    slow_replica.node.nodeIbStasher.delay(
+        cDelay(instId=1, sender_filter=other_replicas[0].node.name))
+    slow_replica.node.nodeIbStasher.delay(
+        cDelay(instId=1, sender_filter=other_replicas[1].node.name))
+
+    # Send a request for which the replica will not be able to order the batch
+    # due to an insufficient count of Commits
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client, 1)
+    looper.runFor(waits.expectedTransactionExecutionTime(4))
+
+    # Receive further Commits from now on
+    slow_replica.node.nodeIbStasher.drop_delayeds()
+    slow_replica.node.nodeIbStasher.resetDelays()
+
+    # Send requests but in a quantity insufficient
+    # for catch-up number of checkpoints
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client,
+                             Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP *
+                             reqs_for_checkpoint - 2)
+    looper.runFor(waits.expectedTransactionExecutionTime(4))
+
+    # Don't receive Checkpoints
+    slow_replica.node.nodeIbStasher.delay(chk_delay(instId=1))
+
+    # Send more requests to reach catch-up number of checkpoints
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client,
+                             reqs_for_checkpoint)
+    # Send a request that starts a new checkpoint
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client, 1)
+    looper.runFor(waits.expectedTransactionExecutionTime(4))
+
+    # Ensure that the replica has not ordered any batches
+    # after the very first one
+    assert slow_replica.last_ordered_3pc == (view_no, 1)
+
+    # Ensure that the watermarks have not been shifted since the view start
+    assert slow_replica.h == 0
+    assert slow_replica.H == 15
+
+    # Ensure that there are some quorumed stashed checkpoints
+    assert slow_replica.stashed_checkpoints_with_quorum()
+
+    # Receive belated Checkpoints
+    slow_replica.node.nodeIbStasher.reset_delays_and_process_delayeds()
+
+    # Ensure that the replica has ordered the batch for the last sent request
+    looper.run(
+        eventually(lambda: assertExp(slow_replica.last_ordered_3pc ==
+                                     (view_no, (Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP + 1) * CHK_FREQ + 1)),
+                   retryWait=1,
+                   timeout=waits.expectedTransactionExecutionTime(4)))
+
+    # Ensure that the watermarks have been shifted so that the lower watermark
+    # now equals to the end of the last stable checkpoint in the instance
+    assert slow_replica.h == (Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP + 1) * CHK_FREQ
+    assert slow_replica.H == (Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP + 1) * CHK_FREQ + 15
+
+    # Ensure that now there are no quorumed stashed checkpoints
+    assert not slow_replica.stashed_checkpoints_with_quorum()
+
+    # Send a request and ensure that the replica orders the batch for it
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client, 1)
+
+    looper.run(
+        eventually(lambda: assertExp(slow_replica.last_ordered_3pc ==
+                                     (view_no, (Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP + 1) * CHK_FREQ + 2)),
                    retryWait=1,
                    timeout=waits.expectedTransactionExecutionTime(4)))

--- a/plenum/test/checkpoints/test_backup_replica_resumes_ordering_on_lag_in_checkpoints.py
+++ b/plenum/test/checkpoints/test_backup_replica_resumes_ordering_on_lag_in_checkpoints.py
@@ -1,0 +1,146 @@
+import pytest
+
+from plenum.common.constants import DOMAIN_LEDGER_ID
+from plenum.server.replica import Replica
+from plenum.test import waits
+from plenum.test.delayers import cDelay
+from plenum.test.helper import sdk_send_random_requests, assertExp
+from plenum.test.test_node import getNonPrimaryReplicas, getPrimaryReplica, \
+    ensureElectionsDone
+from plenum.test.view_change.helper import ensure_view_change
+from stp_core.loop.eventually import eventually
+
+nodeCount = 4
+
+CHK_FREQ = 5
+LOG_SIZE = 3 * CHK_FREQ
+
+
+@pytest.fixture(scope='function')
+def view_change_done(looper, txnPoolNodeSet):
+    ensure_view_change(looper, txnPoolNodeSet)
+    ensureElectionsDone(looper=looper, nodes=txnPoolNodeSet)
+
+
+@pytest.fixture(scope='function',
+                params=['primary', 'non-primary'])
+def one_replica_and_others_in_backup_instance(
+        request, txnPoolNodeSet, view_change_done):
+
+    backup_inst_id = 1
+
+    primary = getPrimaryReplica(txnPoolNodeSet, backup_inst_id)
+    non_primaries = getNonPrimaryReplicas(txnPoolNodeSet, backup_inst_id)
+
+    if request.param == 'primary':
+        return primary, non_primaries
+    else:
+        return non_primaries[0], [primary] + non_primaries[1:]
+
+
+def test_backup_replica_resumes_ordering_on_lag_in_checkpoints(
+        looper, chkFreqPatched, reqs_for_checkpoint,
+        sdk_pool_handle, sdk_wallet_client,
+        one_replica_and_others_in_backup_instance):
+    """
+    Verifies resumption of ordering 3PC-batches on a backup replica
+    on detection of a lag in checkpoints
+    """
+
+    slow_replica, other_replicas = one_replica_and_others_in_backup_instance
+    view_no = slow_replica.viewNo
+
+    # Send a request
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client, 1)
+
+    # Ensure that the backup replica has ordered the batch for it
+    looper.run(
+        eventually(lambda: assertExp(slow_replica.last_ordered_3pc == (view_no, 1)),
+                   retryWait=1,
+                   timeout=waits.expectedTransactionExecutionTime(4)))
+
+    # Don't receive Commits from two replicas
+    slow_replica.node.nodeIbStasher.delay(
+        cDelay(instId=1, sender_filter=other_replicas[0].node.name))
+    slow_replica.node.nodeIbStasher.delay(
+        cDelay(instId=1, sender_filter=other_replicas[1].node.name))
+
+    # Send a request for which the replica will not be able to order the batch
+    # due to an insufficient count of Commits
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client, 1)
+
+    looper.runFor(waits.expectedTransactionExecutionTime(4))
+
+    # Recover reception of Commits
+    slow_replica.node.nodeIbStasher.resetDelays()
+
+    # Send requests but in a quantity insufficient
+    # for catch-up number of checkpoints
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client,
+                             Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP *
+                             reqs_for_checkpoint - 2)
+
+    # Ensure that the replica has not ordered the batches
+    looper.runFor(waits.expectedTransactionExecutionTime(4))
+    assert slow_replica.last_ordered_3pc == (view_no, 1)
+
+    # Ensure that the watermarks have not been shifted since the view start
+    assert slow_replica.h == 0
+    assert slow_replica.H == 15
+
+    # Ensure that the collections related to requests, batches and
+    # own checkpoints are not empty.
+    # (Note that a primary replica removes requests from requestQueues
+    # when creating a batch with them.)
+    if slow_replica.isPrimary:
+        assert slow_replica.sentPrePrepares
+    else:
+        assert slow_replica.requestQueues[DOMAIN_LEDGER_ID]
+        assert slow_replica.prePrepares
+    assert slow_replica.prepares
+    assert slow_replica.commits
+    assert slow_replica.batches
+    assert slow_replica.checkpoints
+
+    # Ensure that there are some quorumed stashed checkpoints
+    assert slow_replica.stashed_checkpoints_with_quorum()
+
+    # Send more requests to reach catch-up number of checkpoints
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client,
+                             reqs_for_checkpoint)
+
+    # Ensure that the replica has adjusted last_ordered_3pc to the end
+    # of the last checkpoint
+    looper.run(
+        eventually(lambda: assertExp(slow_replica.last_ordered_3pc ==
+                                     (view_no, (Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP + 1) * CHK_FREQ)),
+                   retryWait=1,
+                   timeout=waits.expectedTransactionExecutionTime(4)))
+
+    # Ensure that the watermarks have been shifted so that the lower watermark
+    # has the same value as last_ordered_3pc
+    assert slow_replica.h == (Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP + 1) * CHK_FREQ
+    assert slow_replica.H == (Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP + 1) * CHK_FREQ + 15
+
+    # Ensure that the collections related to requests, batches and
+    # own checkpoints have been cleared
+    assert not slow_replica.requestQueues[DOMAIN_LEDGER_ID]
+    assert not slow_replica.sentPrePrepares
+    assert not slow_replica.prePrepares
+    assert not slow_replica.prepares
+    assert not slow_replica.commits
+    assert not slow_replica.batches
+    assert not slow_replica.checkpoints
+
+    # Ensure that now there are no quorumed stashed checkpoints
+    assert not slow_replica.stashed_checkpoints_with_quorum()
+
+    # Send a request
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client, 1)
+
+    # Ensure that the replica has ordered the batch for the sent request
+    looper.run(
+        eventually(lambda: assertExp(slow_replica.last_ordered_3pc ==
+                                     (view_no, (Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP + 1) * CHK_FREQ + 1)),
+                   retryWait=1,
+                   timeout=waits.expectedTransactionExecutionTime(4)))

--- a/plenum/test/checkpoints/test_stashed_messages_processed_on_backup_replica_ordering_resumption.py
+++ b/plenum/test/checkpoints/test_stashed_messages_processed_on_backup_replica_ordering_resumption.py
@@ -1,0 +1,119 @@
+from plenum.server.replica import Replica
+from plenum.test import waits
+from plenum.test.delayers import cDelay, chk_delay
+from plenum.test.helper import sdk_send_random_requests, assertExp
+from stp_core.loop.eventually import eventually
+
+nodeCount = 4
+
+CHK_FREQ = 5
+
+# LOG_SIZE in checkpoints corresponds to the catch-up lag in checkpoints
+LOG_SIZE = 2 * CHK_FREQ
+
+
+def test_stashed_messages_processed_on_backup_replica_ordering_resumption(
+        looper, chkFreqPatched, reqs_for_checkpoint,
+        one_replica_and_others_in_backup_instance,
+        sdk_pool_handle, sdk_wallet_client, view_change_done):
+    """
+    Verifies resumption of ordering 3PC-batches on a backup replica
+    on detection of a lag in checkpoints in case it is detected after
+    some 3PC-messages related to the next checkpoint have already been stashed
+    as laying outside of the watermarks
+    """
+
+    slow_replica, other_replicas = one_replica_and_others_in_backup_instance
+    view_no = slow_replica.viewNo
+
+    # Send a request and ensure that the replica orders the batch for it
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client, 1)
+
+    looper.run(
+        eventually(lambda: assertExp(slow_replica.last_ordered_3pc == (view_no, 1)),
+                   retryWait=1,
+                   timeout=waits.expectedTransactionExecutionTime(4)))
+
+    # Don't receive Commits from two replicas
+    slow_replica.node.nodeIbStasher.delay(
+        cDelay(instId=1, sender_filter=other_replicas[0].node.name))
+    slow_replica.node.nodeIbStasher.delay(
+        cDelay(instId=1, sender_filter=other_replicas[1].node.name))
+
+    # Send a request for which the replica will not be able to order the batch
+    # due to an insufficient count of Commits
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client, 1)
+    looper.runFor(waits.expectedTransactionExecutionTime(4))
+
+    # Receive further Commits from now on
+    slow_replica.node.nodeIbStasher.drop_delayeds()
+    slow_replica.node.nodeIbStasher.resetDelays()
+
+    # Send requests but in a quantity insufficient
+    # for catch-up number of checkpoints
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client,
+                             Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP *
+                             reqs_for_checkpoint - 2)
+    looper.runFor(waits.expectedTransactionExecutionTime(4))
+
+    # Don't receive Checkpoints
+    slow_replica.node.nodeIbStasher.delay(chk_delay(instId=1))
+
+    # Send more requests to reach catch-up number of checkpoints
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client,
+                             reqs_for_checkpoint)
+    looper.runFor(waits.expectedTransactionExecutionTime(4))
+
+    # Ensure that there are no 3PC-messages stashed
+    # as laying outside of the watermarks
+    assert not slow_replica.stashingWhileOutsideWaterMarks
+
+    # Send a request for which the batch will be outside of the watermarks
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client, 1)
+    looper.runFor(waits.expectedTransactionExecutionTime(4))
+
+    # Ensure that the replica has not ordered any batches
+    # after the very first one
+    assert slow_replica.last_ordered_3pc == (view_no, 1)
+
+    # Ensure that the watermarks have not been shifted since the view start
+    assert slow_replica.h == 0
+    assert slow_replica.H == 10
+
+    # Ensure that there are some quorumed stashed checkpoints
+    assert slow_replica.stashed_checkpoints_with_quorum()
+
+    # Ensure that now there are 3PC-messages stashed
+    # as laying outside of the watermarks
+    assert slow_replica.stashingWhileOutsideWaterMarks
+
+    # Receive belated Checkpoints
+    slow_replica.node.nodeIbStasher.reset_delays_and_process_delayeds()
+
+    # Ensure that the replica has ordered the batch for the last sent request
+    looper.run(
+        eventually(lambda: assertExp(slow_replica.last_ordered_3pc ==
+                                     (view_no, (Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP + 1) * CHK_FREQ + 1)),
+                   retryWait=1,
+                   timeout=waits.expectedTransactionExecutionTime(4)))
+
+    # Ensure that the watermarks have been shifted so that the lower watermark
+    # now equals to the end of the last stable checkpoint in the instance
+    assert slow_replica.h == (Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP + 1) * CHK_FREQ
+    assert slow_replica.H == (Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP + 1) * CHK_FREQ + 10
+
+    # Ensure that now there are no quorumed stashed checkpoints
+    assert not slow_replica.stashed_checkpoints_with_quorum()
+
+    # Ensure that now there are no 3PC-messages stashed
+    # as laying outside of the watermarks
+    assert not slow_replica.stashingWhileOutsideWaterMarks
+
+    # Send a request and ensure that the replica orders the batch for it
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client, 1)
+
+    looper.run(
+        eventually(lambda: assertExp(slow_replica.last_ordered_3pc ==
+                                     (view_no, (Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP + 1) * CHK_FREQ + 2)),
+                   retryWait=1,
+                   timeout=waits.expectedTransactionExecutionTime(4)))

--- a/plenum/test/checkpoints/test_watermarks_on_delayed_backup.py
+++ b/plenum/test/checkpoints/test_watermarks_on_delayed_backup.py
@@ -43,17 +43,17 @@ def test_watermarks_restored_after_stable(
 
     # 3. send requests to reach Replica.STASHED_CHECKPOINTS_BEFORE_CATCHUP + 1
     # quorumed checkpoints.
-    # The broken replica should correct watermarks.
+    # The broken replica should adjust last_ordered_3pc and shift watermarks.
     sdk_send_batches_of_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle, sdk_wallet_client,
                                          num_reqs=1, num_batches=1)
-    assert broken_replica.last_ordered_3pc == (0, 0)
+    assert broken_replica.last_ordered_3pc == (0, 10)
     assert broken_replica.h == 10
     assert broken_replica.H == 30
     assert non_broken_replica.last_ordered_3pc == (0, 10)
     assert non_broken_replica.h == 10
     assert non_broken_replica.H == 30
 
-    # 4. Repair broken replica amd make sure that it participates in consensus
+    # 4. Repair broken replica and make sure that it participates in consensus
     # (after watermarks were corrected).
     repair_broken_replica(broken_replica)
     sdk_send_batches_of_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle, sdk_wallet_client,

--- a/plenum/test/primary_selection/test_primary_selection.py
+++ b/plenum/test/primary_selection/test_primary_selection.py
@@ -75,12 +75,6 @@ def catchup_complete_count(txnPoolNodeSet):
     return {n.name: n.spylog.count(n.allLedgersCaughtUp) for n in txnPoolNodeSet}
 
 
-@pytest.fixture(scope='module')  # noqa
-def view_change_done(looper, txnPoolNodeSet):
-    ensure_view_change(looper, txnPoolNodeSet)
-    ensureElectionsDone(looper=looper, nodes=txnPoolNodeSet)
-
-
 # noinspection PyIncorrectDocstring
 
 


### PR DESCRIPTION
- Added a test verifying resumption of ordering 3PC-batches on a backup replica on detection of a lag in checkpoints.
- Added a variant of the test verifying resumption of ordering in case the lag is detected after some batch in the next checkpoint has already been committed but cannot be ordered out of turn.
- Added a variant of the test verifying resumption of ordering in case the lag is detected after some 3PC-messages related to the next checkpoint have already been stashed as laying outside of the watermarks.
- Implemented resumption of ordering 3PC-batches on a backup replica on detection of a lag in checkpoints.
- Corrected one existing test according to the made changes.
- Removed an unused fixture.