### PR TITLE
INDY-1815: areBackupsDegraded() are not use latency anymore

### DIFF
--- a/plenum/server/monitor.py
+++ b/plenum/server/monitor.py
@@ -445,8 +445,7 @@ class Monitor(HasActionQueue, PluginLoaderHelper):
                     slow_instances.append(instance)
         else:
             for instance in self.instances.backupIds:
-                if self.is_instance_throughput_too_low(instance) or \
-                        self.is_instance_avg_req_latency_too_high(instance):
+                if self.is_instance_throughput_too_low(instance):
                     slow_instances.append(instance)
         return slow_instances
 
@@ -474,18 +473,16 @@ class Monitor(HasActionQueue, PluginLoaderHelper):
         Return whether the throughput of the master instance is greater than the
         acceptable threshold
         """
-        logging = self.instances.masterId == inst_id
         r = self.instance_throughput_ratio(inst_id)
         if r is None:
-            if logging:
-                logger.debug("{} instance {} throughput is not "
-                             "measurable.".format(self, inst_id))
+            logger.debug("{} instance {} throughput is not "
+                         "measurable.".format(self, inst_id))
             return None
         too_low = r < self.Delta
-        if logging and too_low:
+        if too_low:
             logger.display("{}{} instance {} throughput ratio {} is lower than Delta {}.".
                            format(MONITORING_PREFIX, self, inst_id, r, self.Delta))
-        elif logging:
+        else:
             logger.trace("{} instance {} throughput ratio {} is acceptable.".
                          format(self, inst_id, r))
         return too_low


### PR DESCRIPTION
Changes:
- remove checking is_instance_avg_req_latency_too_high() from areBackupsDegraded()
- added test_replica_not_degraded_with_too_high_latency