### PR TITLE
INDY-1879: faster way for pool transactions ordering

### DIFF
--- a/plenum/common/stack_manager.py
+++ b/plenum/common/stack_manager.py
@@ -282,25 +282,6 @@ class TxnStackManager(metaclass=ABCMeta):
     def nodeIds(self) -> set:
         return {get_payload_data(txn)[TARGET_NYM] for _, txn in self.ledger.getAllTxn()}
 
-    def getNodeInfoFromLedger(self, nym, excludeLast=True):
-        # Returns the info of the node from the ledger with transaction
-        # sequence numbers that added or updated the info excluding the last
-        # update transaction. The reason for ignoring last transactions is that
-        #  it is used after update to the ledger has already been made
-        txns = []
-        nodeTxnSeqNos = []
-        for seqNo, txn in self.ledger.getAllTxn():
-            txn_data = get_payload_data(txn)
-            if get_type(txn) == NODE and txn_data[TARGET_NYM] == nym:
-                txns.append(txn)
-                nodeTxnSeqNos.append(seqNo)
-        info = {}
-        if len(txns) > 1 and excludeLast:
-            txns = txns[:-1]
-        for txn in txns:
-            self.updateNodeTxns(info, get_payload_data(txn))
-        return nodeTxnSeqNos, info
-
     def getNodesServices(self):
         # Returns services for each node
         srvs = dict()

--- a/plenum/server/pool_manager.py
+++ b/plenum/server/pool_manager.py
@@ -379,9 +379,7 @@ class TxnPoolManager(PoolManager, TxnStackManager):
             self.node.update_bls_key(bls_key)
 
     def getNodeName(self, nym):
-        # Assuming ALIAS does not change
-        _, nodeTxn = self.getNodeInfoFromLedger(nym)
-        return nodeTxn[DATA][ALIAS]
+        return self._ordered_node_ids[nym]
 
     @property
     def merkleRootHash(self) -> str:
@@ -390,10 +388,6 @@ class TxnPoolManager(PoolManager, TxnStackManager):
     @property
     def txnSeqNo(self) -> int:
         return self.ledger.seqNo
-
-    def getNodeData(self, nym):
-        _, nodeTxn = self.getNodeInfoFromLedger(nym)
-        return nodeTxn[DATA]
 
     # Question: Why are `_isIpAddressValid` and `_isPortValid` part of
     # pool_manager?

--- a/plenum/server/pool_manager.py
+++ b/plenum/server/pool_manager.py
@@ -243,6 +243,7 @@ class TxnPoolManager(PoolManager, TxnStackManager):
         # If nodeNym is never added in self._ordered_node_services,
         # nodeNym is never added in ledger
         if nodeNym not in self._ordered_node_services:
+            txn_data[DATA].setdefault(SERVICES, [])
             if VALIDATOR in txn_data[DATA].get(SERVICES, []):
                 self.addNewNodeAndConnect(txn_data)
         else:
@@ -351,7 +352,8 @@ class TxnPoolManager(PoolManager, TxnStackManager):
                 self.node.nodeJoined(txn_data)
 
                 if self.name != nodeName:
-                    self.connectNewRemote(node_info, nodeName, self.node)
+                    self.connectNewRemote({DATA: node_info,
+                                           TARGET_NYM: nodeNym}, nodeName, self.node)
 
             if VALIDATOR in oldServices.difference(newServices):
                 # If validator service is disabled

--- a/plenum/test/pool_transactions/conftest.py
+++ b/plenum/test/pool_transactions/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from plenum.common.constants import NODE
+from plenum.common.txn_util import get_type
 from plenum.common.util import randomString
 from plenum.test.test_node import checkNodesConnected, TestNode
 from plenum.test.pool_transactions.helper import \
@@ -43,3 +45,13 @@ def sdk_node_theta_added(looper,
     looper.run(checkNodesConnected(txnPoolNodeSet))
     sdk_pool_refresh(looper, sdk_pool_handle)
     return new_steward_wallet, new_node
+
+
+@pytest.fixture()
+def pool_node_txns(poolTxnData):
+    node_txns = []
+    for txn in poolTxnData["txns"]:
+        if get_type(txn) == NODE:
+            node_txns.append(txn)
+    return node_txns
+

--- a/plenum/test/pool_transactions/test_add_node_with_invalid_key_proof.py
+++ b/plenum/test/pool_transactions/test_add_node_with_invalid_key_proof.py
@@ -1,12 +1,9 @@
 import pytest
-from plenum.common.config_helper import PNodeConfigHelper
 from plenum.common.exceptions import RequestNackedException
 from plenum.test.helper import sdk_get_and_check_replies
 from plenum.common.constants import VALIDATOR
 from plenum.test.pool_transactions.helper import prepare_new_node_data, \
-    prepare_node_request, sdk_sign_and_send_prepared_request, \
-    create_and_start_new_node
-from plenum.test.test_node import TestNode
+    prepare_node_request, sdk_sign_and_send_prepared_request
 
 
 def test_add_node_with_invalid_key_proof(looper,

--- a/plenum/test/pool_transactions/test_nodes_data_changed.py
+++ b/plenum/test/pool_transactions/test_nodes_data_changed.py
@@ -9,7 +9,7 @@ from plenum.common.constants import CLIENT_STACK_SUFFIX
 from plenum.common.util import randomString, hexToFriendly
 from plenum.test.pool_transactions.helper import sdk_send_update_node, \
     sdk_add_new_steward_and_node, sdk_pool_refresh, \
-    update_node_data_and_reconnect
+    update_node_data_and_reconnect, demote_node
 from plenum.test.test_node import checkNodesConnected
 
 from stp_core.common.log import getlogger
@@ -72,6 +72,33 @@ def testNodePortChanged(looper, txnPoolNodeSet,
     new_port = node_new_ha.port
     node_ha = txnPoolNodeSet[0].nodeReg[new_node.name]
     cli_ha = txnPoolNodeSet[0].cliNodeReg[new_node.name + CLIENT_STACK_SUFFIX]
+
+    update_node_data_and_reconnect(looper, txnPoolNodeSet,
+                                   new_steward_wallet,
+                                   sdk_pool_handle,
+                                   new_node,
+                                   node_ha.host, new_port,
+                                   cli_ha.host, cli_ha.port,
+                                   tdir, tconf)
+    sdk_ensure_pool_functional(looper, txnPoolNodeSet, new_steward_wallet, sdk_pool_handle)
+
+
+def test_node_port_changed_in_promote_after_demote(looper, txnPoolNodeSet,
+                        sdk_wallet_steward,
+                        sdk_pool_handle,
+                        sdk_node_theta_added,
+                        tdir, tconf):
+    """
+    An running node's port is changed
+    """
+    new_steward_wallet, new_node = sdk_node_theta_added
+
+    node_new_ha = genHa(1)
+    new_port = node_new_ha.port
+    node_ha = txnPoolNodeSet[0].nodeReg[new_node.name]
+    cli_ha = txnPoolNodeSet[0].cliNodeReg[new_node.name + CLIENT_STACK_SUFFIX]
+
+    demote_node(looper, new_steward_wallet, sdk_pool_handle, new_node)
 
     update_node_data_and_reconnect(looper, txnPoolNodeSet,
                                    new_steward_wallet,

--- a/plenum/test/pool_transactions/test_nodes_data_changed.py
+++ b/plenum/test/pool_transactions/test_nodes_data_changed.py
@@ -83,33 +83,6 @@ def testNodePortChanged(looper, txnPoolNodeSet,
     sdk_ensure_pool_functional(looper, txnPoolNodeSet, new_steward_wallet, sdk_pool_handle)
 
 
-def test_node_port_changed_in_promote_after_demote(looper, txnPoolNodeSet,
-                        sdk_wallet_steward,
-                        sdk_pool_handle,
-                        sdk_node_theta_added,
-                        tdir, tconf):
-    """
-    A running node's port is changed
-    """
-    new_steward_wallet, new_node = sdk_node_theta_added
-
-    node_new_ha = genHa(1)
-    new_port = node_new_ha.port
-    node_ha = txnPoolNodeSet[0].nodeReg[new_node.name]
-    cli_ha = txnPoolNodeSet[0].cliNodeReg[new_node.name + CLIENT_STACK_SUFFIX]
-
-    demote_node(looper, new_steward_wallet, sdk_pool_handle, new_node)
-
-    update_node_data_and_reconnect(looper, txnPoolNodeSet,
-                                   new_steward_wallet,
-                                   sdk_pool_handle,
-                                   new_node,
-                                   node_ha.host, new_port,
-                                   cli_ha.host, cli_ha.port,
-                                   tdir, tconf)
-    sdk_ensure_pool_functional(looper, txnPoolNodeSet, new_steward_wallet, sdk_pool_handle)
-
-
 def test_fail_node_bls_key_validation(looper,
                                       sdk_pool_handle,
                                       sdk_node_theta_added):

--- a/plenum/test/pool_transactions/test_nodes_data_changed.py
+++ b/plenum/test/pool_transactions/test_nodes_data_changed.py
@@ -64,7 +64,7 @@ def testNodePortChanged(looper, txnPoolNodeSet,
                         sdk_node_theta_added,
                         tdir, tconf):
     """
-    An running node's port is changed
+    A running node's port is changed
     """
     new_steward_wallet, new_node = sdk_node_theta_added
 
@@ -89,7 +89,7 @@ def test_node_port_changed_in_promote_after_demote(looper, txnPoolNodeSet,
                         sdk_node_theta_added,
                         tdir, tconf):
     """
-    An running node's port is changed
+    A running node's port is changed
     """
     new_steward_wallet, new_node = sdk_node_theta_added
 

--- a/plenum/test/pool_transactions/test_on_pool_membership_changes.py
+++ b/plenum/test/pool_transactions/test_on_pool_membership_changes.py
@@ -1,0 +1,54 @@
+import pytest
+
+from plenum.common.config_helper import PNodeConfigHelper
+from plenum.test.test_node import TestNode
+
+from plenum.common.txn_util import get_payload_data
+
+from plenum.common.constants import TARGET_NYM, DATA, SERVICES, VALIDATOR, TXN_PAYLOAD
+from plenum.test.testing_utils import FakeSomething
+
+
+@pytest.fixture(scope='function')
+def test_node(tdirWithPoolTxns,
+              tdirWithDomainTxns,
+              poolTxnNodeNames,
+              tdirWithNodeKeepInited,
+              tdir,
+              tconf,
+              allPluginsPath):
+    node_name = poolTxnNodeNames[0]
+    config_helper = PNodeConfigHelper(node_name, tconf, chroot=tdir)
+    node = TestNode(
+        node_name,
+        config_helper=config_helper,
+        config=tconf,
+        pluginPaths=allPluginsPath)
+    node.view_changer = FakeSomething(view_change_in_progress=False,
+                                      view_no=0)
+    yield node
+    node.onStopping()
+
+
+def test_on_pool_membership_changes(test_node, pool_node_txns):
+    def get_all_txn():
+        assert False, "ledger.getAllTxn() shouldn't be called in onPoolMembershipChange()"
+
+    pool_manager = test_node.poolManager
+    pool_manager.ledger.getAllTxn = get_all_txn
+
+    txn = pool_node_txns[0]
+    node_nym = get_payload_data(txn)[TARGET_NYM]
+
+    txn[TXN_PAYLOAD][DATA][DATA][SERVICES] = []
+    assert node_nym in pool_manager._ordered_node_services
+    pool_manager.onPoolMembershipChange(txn)
+    assert pool_manager._ordered_node_services[node_nym] == []
+
+    txn[TXN_PAYLOAD][DATA][DATA][SERVICES] = [VALIDATOR]
+    pool_manager.onPoolMembershipChange(txn)
+    assert pool_manager._ordered_node_services[node_nym] == [VALIDATOR]
+
+    txn[TXN_PAYLOAD][DATA][DATA][SERVICES] = []
+    pool_manager.onPoolMembershipChange(pool_node_txns[0])
+    assert pool_manager._ordered_node_services[node_nym] == []

--- a/plenum/test/pool_transactions/test_txn_pool_manager.py
+++ b/plenum/test/pool_transactions/test_txn_pool_manager.py
@@ -1,4 +1,7 @@
 import pytest
+
+from plenum.common.config_helper import PNodeConfigHelper
+from plenum.test.test_node import TestNode
 from stp_core.loop.eventually import eventually
 
 from plenum.common.metrics_collector import MetricsName
@@ -7,7 +10,8 @@ from plenum.test.helper import sdk_send_random_and_check
 
 from plenum.common.txn_util import get_type, get_payload_data
 
-from plenum.common.constants import TARGET_NYM, NODE, CLIENT_STACK_SUFFIX, DATA, ALIAS, SERVICES
+from plenum.common.constants import TARGET_NYM, NODE, \
+    CLIENT_STACK_SUFFIX, DATA, ALIAS, SERVICES, VALIDATOR, TXN_PAYLOAD
 from plenum.test.pool_transactions.helper import demote_node
 
 nodeCount = 7
@@ -21,6 +25,27 @@ def pool_node_txns(poolTxnData):
         if get_type(txn) == NODE:
             node_txns.append(txn)
     return node_txns
+
+
+@pytest.fixture(scope='function')
+def test_node(
+        tdirWithPoolTxns,
+        tdirWithDomainTxns,
+        poolTxnNodeNames,
+        tdirWithNodeKeepInited,
+        tdir,
+        tconf,
+        allPluginsPath):
+
+    node_name = poolTxnNodeNames[0]
+    config_helper = PNodeConfigHelper(node_name, tconf, chroot=tdir)
+    node = TestNode(
+        node_name,
+        config_helper=config_helper,
+        config=tconf,
+        pluginPaths=allPluginsPath)
+    yield node
+    node.onStopping()
 
 
 def test_twice_demoted_node_dont_write_txns(txnPoolNodeSet,
@@ -95,3 +120,27 @@ def check_get_nym_by_name(txnPoolNodeSet, pool_node_txns):
 
         assert node_nym
         assert node_nym == expected_data
+
+
+def test_on_pool_membership_changes(test_node, pool_node_txns):
+
+    def get_all_txn():
+        assert False, "ledger.getAllTxn() shouldn't be called in onPoolMembershipChange()"
+    pool_manager = test_node.poolManager
+    pool_manager.ledger.getAllTxn = get_all_txn
+
+    txn = pool_node_txns[0]
+    node_nym = get_payload_data(txn)[TARGET_NYM]
+
+    txn[TXN_PAYLOAD][DATA][DATA][SERVICES] = []
+    assert node_nym not in pool_manager._ordered_node_services
+    pool_manager.onPoolMembershipChange(txn)
+    assert pool_manager._ordered_node_services[node_nym] == []
+
+    txn[TXN_PAYLOAD][DATA][DATA][SERVICES] = [VALIDATOR]
+    pool_manager.onPoolMembershipChange(txn)
+    assert pool_manager._ordered_node_services[node_nym] == [VALIDATOR]
+
+    txn[TXN_PAYLOAD][DATA][DATA][SERVICES] = []
+    pool_manager.onPoolMembershipChange(pool_node_txns[0])
+    assert pool_manager._ordered_node_services[node_nym] == []


### PR DESCRIPTION
- remove getNodeData fron PoolManager
- remove getAllTxn from nodeServicesChanged
- remove getAllTxn from onPoolMembershipChange
- getNodeName - change to using _ordered_node_ids