### PR TITLE
INDY-1896: Allow "read" and "action" requests processing

### DIFF
--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -1964,17 +1964,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         :param msg: a client message
         :param frm: the name of the client that sent this `msg`
         """
-        if self.view_changer.view_change_in_progress:
 
-            msg_dict = msg if isinstance(msg, dict) else msg.as_dict
-            self.discard(msg_dict,
-                         reason="view change in progress",
-                         logMethod=logger.debug)
-            self.send_nack_to_client((idr_from_req_data(msg_dict),
-                                      msg_dict.get(f.REQ_ID.nm, None)),
-                                     "Client request is discarded since view "
-                                     "change is in progress", frm)
-            return
         if isinstance(msg, Batch):
             for m in msg.messages:
                 # This check is done since Client uses NodeStack (which can
@@ -1987,6 +1977,23 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
                 m = self.clientstack.deserializeMsg(m)
                 self.handleOneClientMsg((m, frm))
         else:
+            msg_dict = msg.as_dict if isinstance(msg, Request) else msg
+            if isinstance(msg_dict, dict):
+                txn_type = msg_dict.get(OPERATION).get(TXN_TYPE, False) \
+                    if OPERATION in msg_dict \
+                    else False
+                txn_need_quorum = txn_type and not (txn_type == GET_TXN or
+                                                    self.is_action(txn_type) or
+                                                    self.is_query(txn_type))
+                if self.view_changer.view_change_in_progress and txn_need_quorum:
+                    self.discard(msg_dict,
+                                 reason="view change in progress",
+                                 logMethod=logger.debug)
+                    self.send_nack_to_client((idr_from_req_data(msg_dict),
+                                              msg_dict.get(f.REQ_ID.nm, None)),
+                                             "Client request is discarded since view "
+                                             "change is in progress", frm)
+                    return
             self.postToClientInBox(msg, frm)
 
     def postToClientInBox(self, msg, frm):

--- a/plenum/test/conftest.py
+++ b/plenum/test/conftest.py
@@ -1094,3 +1094,23 @@ def one_replica_and_others_in_backup_instance(
         return primary, non_primaries
     else:
         return non_primaries[0], [primary] + non_primaries[1:]
+
+
+@pytest.fixture(scope='function')
+def test_node(
+        tdirWithPoolTxns,
+        tdirWithDomainTxns,
+        poolTxnNodeNames,
+        tdirWithNodeKeepInited,
+        tdir,
+        tconf,
+        allPluginsPath):
+    node_name = poolTxnNodeNames[0]
+    config_helper = PNodeConfigHelper(node_name, tconf, chroot=tdir)
+    node = TestNode(
+        node_name,
+        config_helper=config_helper,
+        config=tconf,
+        pluginPaths=allPluginsPath)
+    yield node
+    node.onStopping()  # TODO stop won't call onStopping as we are in Stopped state

--- a/plenum/test/node/test_api.py
+++ b/plenum/test/node/test_api.py
@@ -1,31 +1,8 @@
 import pytest
 
 from common.exceptions import LogicError
-from plenum.test.test_node import TestNode
 from plenum.common.constants import TXN_TYPE
-from plenum.common.config_helper import PNodeConfigHelper
 from plenum.common.request import Request
-
-
-@pytest.fixture(scope='function')
-def test_node(
-        tdirWithPoolTxns,
-        tdirWithDomainTxns,
-        poolTxnNodeNames,
-        tdirWithNodeKeepInited,
-        tdir,
-        tconf,
-        allPluginsPath):
-
-    node_name = poolTxnNodeNames[0]
-    config_helper = PNodeConfigHelper(node_name, tconf, chroot=tdir)
-    node = TestNode(
-        node_name,
-        config_helper=config_helper,
-        config=tconf,
-        pluginPaths=allPluginsPath)
-    yield node
-    node.onStopping() # TODO stop won't call onStopping as we are in Stopped state
 
 
 def test_on_view_change_complete_fails(test_node):

--- a/plenum/test/view_change/test_client_req_during_view_change.py
+++ b/plenum/test/view_change/test_client_req_during_view_change.py
@@ -1,11 +1,7 @@
 import pytest
 
 from plenum.common.constants import NODE, TXN_TYPE, GET_TXN
-from plenum.common.exceptions import RequestNackedException
-from plenum.test.helper import sdk_send_random_and_check, \
-    sdk_send_random_requests, sdk_get_and_check_replies, sdk_gen_request, \
-    checkDiscardMsg
-from plenum.test.pool_transactions.helper import sdk_build_get_txn_request, sdk_sign_and_send_prepared_request
+from plenum.test.helper import sdk_gen_request, checkDiscardMsg
 from plenum.test.testing_utils import FakeSomething
 
 
@@ -14,45 +10,6 @@ def test_node(test_node):
     test_node.view_changer = FakeSomething(view_change_in_progress=True,
                                            view_no=1)
     return test_node
-
-
-def test_client_write_request_discard_in_view_change_integration(txnPoolNodeSet,
-                                                       looper,
-                                                       sdk_pool_handle,
-                                                       sdk_wallet_client):
-    '''
-    Check that client requests sent in view change will discard.
-    '''
-    sdk_send_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle,
-                              sdk_wallet_client, 4)
-
-    for node in txnPoolNodeSet:
-        node.view_changer.view_change_in_progress = True
-    discard_reqs = sdk_send_random_requests(looper, sdk_pool_handle,
-                                            sdk_wallet_client, 1)
-    with pytest.raises(RequestNackedException) as e:
-        sdk_get_and_check_replies(looper, discard_reqs)
-        assert "Client request is discarded since view " \
-               "change is in progress" in e.args[0]
-
-
-def test_client_get_request_not_discard_in_view_change_integration(txnPoolNodeSet,
-                                                       looper,
-                                                       sdk_pool_handle,
-                                                       sdk_wallet_client):
-    '''
-    Check that client requests sent in view change will discard.
-    '''
-    for node in txnPoolNodeSet:
-        node.view_changer.view_change_in_progress = True
-    _, steward_did = sdk_wallet_client
-    request = sdk_build_get_txn_request(looper, steward_did, 1)
-
-    sdk_request = sdk_sign_and_send_prepared_request(looper,
-                                               sdk_wallet_client,
-                                               sdk_pool_handle,
-                                               request)
-    sdk_get_and_check_replies(looper, [sdk_request])
 
 
 def test_client_write_request_discard_in_view_change_with_dict(test_node):

--- a/plenum/test/view_change/test_client_req_during_view_change.py
+++ b/plenum/test/view_change/test_client_req_during_view_change.py
@@ -1,12 +1,24 @@
+import functools
+
 import pytest
 
+from plenum.common.constants import NODE, TXN_TYPE, GET_TXN
 from plenum.common.exceptions import RequestNackedException
 from plenum.test.helper import sdk_send_random_and_check, \
     sdk_send_random_requests, sdk_get_and_check_replies, sdk_gen_request, \
     checkDiscardMsg
+from plenum.test.pool_transactions.helper import sdk_build_get_txn_request, sdk_sign_and_send_prepared_request
+from plenum.test.testing_utils import FakeSomething
 
 
-def test_client_msg_discard_in_view_change_integration(txnPoolNodeSet,
+@pytest.fixture(scope='function')
+def test_node(test_node):
+    test_node.view_changer = FakeSomething(view_change_in_progress=True,
+                                           view_no=1)
+    return test_node
+
+
+def test_client_write_request_discard_in_view_change_integration(txnPoolNodeSet,
                                                        looper,
                                                        sdk_pool_handle,
                                                        sdk_wallet_client):
@@ -26,24 +38,55 @@ def test_client_msg_discard_in_view_change_integration(txnPoolNodeSet,
                "change is in progress" in e.args[0]
 
 
-def test_client_msg_discard_in_view_change_with_dict(txnPoolNodeSet):
-    node = txnPoolNodeSet[0]
-    node.view_changer.view_change_in_progress = True
-    node.send_nack_to_client = check_nack_msg
+def test_client_get_request_not_discard_in_view_change_integration(txnPoolNodeSet,
+                                                       looper,
+                                                       sdk_pool_handle,
+                                                       sdk_wallet_client):
+    '''
+    Check that client requests sent in view change will discard.
+    '''
+    for node in txnPoolNodeSet:
+        node.view_changer.view_change_in_progress = True
+    _, steward_did = sdk_wallet_client
+    request = sdk_build_get_txn_request(looper, steward_did, 1)
 
-    msg = sdk_gen_request("op").as_dict
-    node.unpackClientMsg(msg, "frm")
-    checkDiscardMsg([node, ], msg, "view change in progress")
+    sdk_request = sdk_sign_and_send_prepared_request(looper,
+                                               sdk_wallet_client,
+                                               sdk_pool_handle,
+                                               request)
+    sdk_get_and_check_replies(looper, [sdk_request])
 
 
-def test_client_msg_discard_in_view_change_with_request(txnPoolNodeSet):
-    node = txnPoolNodeSet[0]
-    node.view_changer.view_change_in_progress = True
-    node.send_nack_to_client = check_nack_msg
+def test_client_write_request_discard_in_view_change_with_dict(test_node):
+    test_node.send_nack_to_client = check_nack_msg
 
-    msg = sdk_gen_request("op")
-    node.unpackClientMsg(msg, "frm")
-    checkDiscardMsg([node, ], msg.as_dict, "view change in progress")
+    msg = sdk_gen_request({TXN_TYPE: NODE}).as_dict
+    test_node.unpackClientMsg(msg, "frm")
+    checkDiscardMsg([test_node, ], msg, "view change in progress")
+
+
+def test_client_get_request_not_discard_in_view_change_with_dict(test_node):
+    sender = "frm"
+    msg = sdk_gen_request({TXN_TYPE: GET_TXN}).as_dict
+
+    def post_to_client_in_box(received_msg, received_frm):
+        assert received_frm == sender
+        assert received_msg == msg
+    test_node.postToClientInBox = post_to_client_in_box
+
+    def discard(received_msg, reason, logLevel):
+        assert False, "Message {} was discard with '{}'".format(received_msg, reason)
+    test_node.discard = discard
+
+    test_node.unpackClientMsg(msg, sender)
+
+
+def test_client_msg_discard_in_view_change_with_request(test_node):
+    test_node.send_nack_to_client = check_nack_msg
+
+    msg = sdk_gen_request({TXN_TYPE: NODE})
+    test_node.unpackClientMsg(msg, "frm")
+    checkDiscardMsg([test_node, ], msg.as_dict, "view change in progress")
 
 
 def check_nack_msg(req_key, reason, to_client):

--- a/plenum/test/view_change/test_client_req_during_view_change.py
+++ b/plenum/test/view_change/test_client_req_during_view_change.py
@@ -1,5 +1,3 @@
-import functools
-
 import pytest
 
 from plenum.common.constants import NODE, TXN_TYPE, GET_TXN

--- a/plenum/test/view_change/test_client_req_during_view_change_integration.py
+++ b/plenum/test/view_change/test_client_req_during_view_change_integration.py
@@ -1,0 +1,45 @@
+import pytest
+
+from plenum.common.exceptions import RequestNackedException
+from plenum.test.helper import sdk_send_random_and_check, \
+    sdk_send_random_requests, sdk_get_and_check_replies
+from plenum.test.pool_transactions.helper import sdk_build_get_txn_request, sdk_sign_and_send_prepared_request
+
+
+def test_client_write_request_discard_in_view_change_integration(txnPoolNodeSet,
+                                                                 looper,
+                                                                 sdk_pool_handle,
+                                                                 sdk_wallet_client):
+    '''
+    Check that client requests sent in view change will discard.
+    '''
+    sdk_send_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle,
+                              sdk_wallet_client, 4)
+
+    for node in txnPoolNodeSet:
+        node.view_changer.view_change_in_progress = True
+    discard_reqs = sdk_send_random_requests(looper, sdk_pool_handle,
+                                            sdk_wallet_client, 1)
+    with pytest.raises(RequestNackedException) as e:
+        sdk_get_and_check_replies(looper, discard_reqs)
+        assert "Client request is discarded since view " \
+               "change is in progress" in e.args[0]
+
+
+def test_client_get_request_not_discard_in_view_change_integration(txnPoolNodeSet,
+                                                                   looper,
+                                                                   sdk_pool_handle,
+                                                                   sdk_wallet_client):
+    '''
+    Check that client requests sent in view change will discard.
+    '''
+    for node in txnPoolNodeSet:
+        node.view_changer.view_change_in_progress = True
+    _, steward_did = sdk_wallet_client
+    request = sdk_build_get_txn_request(looper, steward_did, 1)
+
+    sdk_request = sdk_sign_and_send_prepared_request(looper,
+                                                     sdk_wallet_client,
+                                                     sdk_pool_handle,
+                                                     request)
+    sdk_get_and_check_replies(looper, [sdk_request])


### PR DESCRIPTION
Changes:
- move View Change check in unpackClientMsg and add check for request type
- add tests
