### PR TITLE
INDY-1836: increase ToleratePrimaryDisconnection and bind re-try time.

### DIFF
--- a/plenum/config.py
+++ b/plenum/config.py
@@ -193,7 +193,7 @@ ViewChangeWindowSize = 60
 
 # A node if finds itself disconnected from primary of the master instance will
 # wait for `ToleratePrimaryDisconnection` before sending a view change message
-ToleratePrimaryDisconnection = 2
+ToleratePrimaryDisconnection = 60
 
 # A node if finds itself disconnected from primary of some backup instance will
 # wait for `TolerateBackupPrimaryDisconnection` before remove its replica

--- a/plenum/test/conftest.py
+++ b/plenum/test/conftest.py
@@ -228,7 +228,8 @@ overriddenConfigValues = {
     },
     "VIEW_CHANGE_TIMEOUT": 60,
     "MIN_TIMEOUT_CATCHUPS_DONE_DURING_VIEW_CHANGE": 15,
-    "INITIAL_PROPOSE_VIEW_CHANGE_TIMEOUT": 60
+    "INITIAL_PROPOSE_VIEW_CHANGE_TIMEOUT": 60,
+    "ToleratePrimaryDisconnection": 2
 }
 
 

--- a/stp_zmq/zstack.py
+++ b/stp_zmq/zstack.py
@@ -380,7 +380,7 @@ class ZStack(NetworkInterface):
                 bound = True
             except zmq.error.ZMQError as zmq_err:
                 bind_retries += 1
-                if bind_retries == 5:
+                if bind_retries == 50:
                     raise zmq_err
                 time.sleep(0.2)
 


### PR DESCRIPTION
ToleratePrimaryDisconnection increased up to 60 seconds.
The bind re-try time increased up to 10 seconds.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>