### PR TITLE
INDY-1836: add test of req drop when replica does not order.

### DIFF
--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -2668,7 +2668,8 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         return key in self.requestSender
 
     def doneProcessingReq(self, key):
-        self.requestSender.pop(key)
+        if key in self.requestSender:
+            self.requestSender.pop(key)
 
     def is_sender_known_for_req(self, key):
         return self.requestSender.get(key) is not None
@@ -3837,7 +3838,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
             outdated = False
             req_state = self.requests[req_key]
 
-            if req_state.executed and req_state.forwardedTo > 0:
+            if req_state.executed and req_state.unordered_by_replicas_num <= 0:
                 # Means that the request has been processed by all replicas and
                 # it just waits for stable checkpoint to be deleted.
                 continue

--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -2247,6 +2247,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
             if reqState:
                 if reqState.forwarded and not reqState.executed:
                     self.mark_request_as_executed(reqState.request)
+                    self.requests.ordered_by_replica(reqState.request.key)
                     self.requests.free(reqState.request.key)
                     self.doneProcessingReq(req_key)
                 if not reqState.forwarded:

--- a/plenum/server/propagator.py
+++ b/plenum/server/propagator.py
@@ -32,6 +32,7 @@ class ReqState:
         self.executed = False
         self.added_ts = time.perf_counter()
         self.finalised_ts = None
+        self.unordered_by_replicas_num = 0
 
     def req_with_acceptable_quorum(self, quorum: Quorum):
         digests = defaultdict(set)
@@ -81,6 +82,15 @@ class Requests(OrderedDict):
         """
         return self[req.key].forwarded
 
+    def ordered_by_replica(self, request_key):
+        """
+        Should be called by each replica when request is ordered or replica is removed.
+        """
+        state = self.get(request_key)
+        if not state:
+            return
+        state.unordered_by_replicas_num -= 1
+
     def mark_as_forwarded(self, req: Request, to: int):
         """
         Works together with 'mark_as_executed' and 'free' methods.
@@ -91,6 +101,7 @@ class Requests(OrderedDict):
         """
         self[req.key].forwarded = True
         self[req.key].forwardedTo = to
+        self[req.key].unordered_by_replicas_num = to
 
     def add_propagate(self, req: Request, sender: str):
         """

--- a/plenum/server/replica.py
+++ b/plenum/server/replica.py
@@ -640,6 +640,7 @@ class Replica(HasActionQueue, MessageProcessor, HookManager):
             if seq_no is not None:
                 reqs_for_remove.append((key, ledger_id, seq_no))
         for key, ledger_id, seq_no in reqs_for_remove:
+            self.requests.ordered_by_replica(key)
             self.requests.free(key)
             self.requestQueues[int(ledger_id)].discard(key)
         master_last_ordered_3pc = self.node.master_replica.last_ordered_3pc

--- a/plenum/server/replica.py
+++ b/plenum/server/replica.py
@@ -1889,6 +1889,7 @@ class Replica(HasActionQueue, MessageProcessor, HookManager):
                 invalid_reqIdr.append(reqIdr)
             else:
                 valid_reqIdr.append(reqIdr)
+            self.requests.ordered_by_replica(reqIdr)
         ordered = Ordered(self.instId,
                           pp.viewNo,
                           valid_reqIdr,

--- a/plenum/server/replicas.py
+++ b/plenum/server/replicas.py
@@ -69,6 +69,7 @@ class Replicas:
 
         for req_key in req_keys:
             if req_key in replica.requests:
+                replica.requests.ordered_by_replica(req_key)
                 replica.requests.free(req_key)
 
         self._messages_to_replicas.pop(inst_id, None)

--- a/plenum/test/req_drop/test_req_drop_when_backup_replica_does_not_order.py
+++ b/plenum/test/req_drop/test_req_drop_when_backup_replica_does_not_order.py
@@ -1,0 +1,78 @@
+import pytest
+
+from plenum.test.helper import sdk_send_random_requests
+from stp_core.loop.eventually import eventually
+
+
+howlong = 20
+nodeCount = 8
+
+
+@pytest.fixture(scope="module")
+def tconf(tconf):
+    OUTDATED_REQS_CHECK_ENABLED_OLD = tconf.OUTDATED_REQS_CHECK_ENABLED
+    OUTDATED_REQS_CHECK_INTERVAL_OLD = tconf.OUTDATED_REQS_CHECK_INTERVAL
+    PROPAGATES_PHASE_REQ_TIMEOUT_OLD = tconf.PROPAGATES_PHASE_REQ_TIMEOUT
+    ORDERING_PHASE_REQ_TIMEOUT_OLD = tconf.ORDERING_PHASE_REQ_TIMEOUT
+    REPLICAS_REMOVING_WITH_DEGRADATION_OLD = tconf.REPLICAS_REMOVING_WITH_DEGRADATION
+    REPLICAS_REMOVING_WITH_PRIMARY_DISCONNECTED_OLD = tconf.REPLICAS_REMOVING_WITH_PRIMARY_DISCONNECTED
+
+    tconf.OUTDATED_REQS_CHECK_ENABLED = True
+    tconf.OUTDATED_REQS_CHECK_INTERVAL = 1
+    tconf.PROPAGATES_PHASE_REQ_TIMEOUT = 3600
+    tconf.ORDERING_PHASE_REQ_TIMEOUT = 20
+    tconf.REPLICAS_REMOVING_WITH_DEGRADATION = None
+    tconf.REPLICAS_REMOVING_WITH_PRIMARY_DISCONNECTED = None
+
+    yield tconf
+
+    tconf.OUTDATED_REQS_CHECK_ENABLED = OUTDATED_REQS_CHECK_ENABLED_OLD
+    tconf.OUTDATED_REQS_CHECK_INTERVAL = OUTDATED_REQS_CHECK_INTERVAL_OLD
+    tconf.PROPAGATES_PHASE_REQ_TIMEOUT = PROPAGATES_PHASE_REQ_TIMEOUT_OLD
+    tconf.ORDERING_PHASE_REQ_TIMEOUT = ORDERING_PHASE_REQ_TIMEOUT_OLD
+    tconf.REPLICAS_REMOVING_WITH_DEGRADATION = REPLICAS_REMOVING_WITH_DEGRADATION_OLD
+    tconf.REPLICAS_REMOVING_WITH_PRIMARY_DISCONNECTED = REPLICAS_REMOVING_WITH_PRIMARY_DISCONNECTED_OLD
+
+
+def test_req_drop_when_backup_replica_does_not_order(
+        tconf, looper, txnPoolNodeSet,
+        sdk_wallet_client, sdk_pool_handle):
+    assert len(txnPoolNodeSet[0].replicas) == 3
+
+    # Stop the primary of backup replica
+    backup_primary_name_off = txnPoolNodeSet[0].replicas[2].primaryName.split(":")[0]
+    for n in txnPoolNodeSet:
+        if n.name == backup_primary_name_off:
+            n.stop()
+
+    initial_ledger_size = txnPoolNodeSet[0].domainLedger.size
+
+    sdk_send_random_requests(looper, sdk_pool_handle, sdk_wallet_client, 1)
+
+    def check_request_queue():
+        for n in txnPoolNodeSet:
+            if n.name != backup_primary_name_off:
+                assert len(n.requests) == 1
+                assert n.propagates_phase_req_timeouts == 0
+                assert n.ordering_phase_req_timeouts == 0
+
+    timeout = howlong
+    looper.run(eventually(check_request_queue, retryWait=.5, timeout=timeout))
+
+    def check_drop():
+        for n in txnPoolNodeSet:
+            if n.name != backup_primary_name_off:
+                assert len(n.requests) == 0
+                assert n.propagates_phase_req_timeouts == 0
+                assert n.ordering_phase_req_timeouts == 1
+
+    timeout = tconf.ORDERING_PHASE_REQ_TIMEOUT + tconf.OUTDATED_REQS_CHECK_INTERVAL + 10
+    looper.run(eventually(check_drop, retryWait=.5, timeout=timeout))
+
+    def check_ledger_size():
+        # The request should be eventually ordered
+        for n in txnPoolNodeSet:
+            if n.name != backup_primary_name_off:
+                assert n.domainLedger.size - initial_ledger_size == 1
+
+    looper.run(eventually(check_ledger_size, retryWait=.5, timeout=timeout))

--- a/plenum/test/requests/test_req_state.py
+++ b/plenum/test/requests/test_req_state.py
@@ -1,0 +1,38 @@
+import functools
+from hashlib import sha256
+
+import pytest
+
+from plenum.common.request import Request
+from plenum.server.propagator import Requests
+
+
+@pytest.fixture(scope="function")
+def requests():
+    def _getDigest(req: Request):
+        return sha256(req.identifier.encode())
+
+    requests = Requests()
+
+    req = Request("1")
+    req.getDigest = functools.partial(_getDigest, req)
+    requests.add(req)
+
+    assert len(requests) == 1
+    return requests, req.key
+
+
+def test_unordered_by_replicas_num(requests):
+    replicas_num = 3
+
+    _requests, req_key = requests
+
+    req_state = _requests[req_key]
+    assert req_state.unordered_by_replicas_num == 0
+
+    _requests.mark_as_forwarded(req_state.request, replicas_num)
+    assert req_state.unordered_by_replicas_num == replicas_num
+
+    for i in range(1, replicas_num + 1):
+        _requests.ordered_by_replica(req_key)
+        assert req_state.unordered_by_replicas_num == replicas_num - i


### PR DESCRIPTION
Also added a new counter unordered_by_replicas_num for req_state
to check how many replicas have not yet ordered particular
request.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>