### PR TITLE
INDY-1876: Change order of stashing

### DIFF
--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -2274,11 +2274,9 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         last_caught_up_3PC = self.ledgerManager.last_caught_up_3PC
         self.mode = Mode.synced
 
-        need_up_and_clear = compare_3PC_keys(self.master_last_ordered_3PC,
-                                             last_caught_up_3PC) > 0
         for replica in self.replicas.values():
             replica.on_catch_up_finished(last_caught_up_3PC=last_caught_up_3PC,
-                                         need_up_and_clear=need_up_and_clear)
+                                         master_last_ordered_3PC=self.master_last_ordered_3PC)
         logger.info('{}{} caught up till {}'
                     .format(CATCH_UP_PREFIX, self, last_caught_up_3PC),
                     extra={'cli': True})

--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -2272,11 +2272,11 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         if self.num_txns_caught_up_in_last_catchup() == 0:
             self.catchup_rounds_without_txns += 1
         last_caught_up_3PC = self.ledgerManager.last_caught_up_3PC
+        master_last_ordered_3PC = self.master_last_ordered_3PC
         self.mode = Mode.synced
-
         for replica in self.replicas.values():
-            replica.on_catch_up_finished(last_caught_up_3PC=last_caught_up_3PC,
-                                         master_last_ordered_3PC=self.master_last_ordered_3PC)
+            replica.on_catch_up_finished(last_caught_up_3PC,
+                                         master_last_ordered_3PC)
         logger.info('{}{} caught up till {}'
                     .format(CATCH_UP_PREFIX, self, last_caught_up_3PC),
                     extra={'cli': True})

--- a/plenum/server/replica.py
+++ b/plenum/server/replica.py
@@ -2598,10 +2598,6 @@ class Replica(HasActionQueue, MessageProcessor, HookManager):
                 compare_3PC_keys(master_last_ordered_3PC,
                                  last_caught_up_3PC) > 0:
             if self.isMaster:
-                if last_caught_up_3PC is None:
-                    self.logger.info("{} - on_catch_up_finished needs "
-                                     "last_caught_up_3PC".format(self))
-                    return
                 self._caught_up_till_3pc(last_caught_up_3PC)
             else:
                 self._catchup_clear_for_backup()

--- a/plenum/server/replica_validator.py
+++ b/plenum/server/replica_validator.py
@@ -37,11 +37,7 @@ class ReplicaValidator:
         if self.replica.has_already_ordered(view_no, pp_seq_no):
             return DISCARD, ALREADY_ORDERED
 
-        # 4. Check watermarks
-        if not (self.replica.h < pp_seq_no <= self.replica.H):
-            return STASH_WATERMARKS, OUTSIDE_WATERMARKS
-
-        # 5. Check viewNo
+        # 4. Check viewNo
         if view_no > self.replica.viewNo:
             return STASH_VIEW, FUTURE_VIEW
         if view_no < self.replica.viewNo - 1:
@@ -60,9 +56,13 @@ class ReplicaValidator:
         if node.is_synced and node.view_change_in_progress:
             return PROCESS, None
 
-        # 6. Check if Participating
+        # 5. Check if Participating
         if not node.isParticipating:
             return STASH_CATCH_UP, CATCHING_UP
+
+        # 6. Check watermarks
+        if not (self.replica.h < pp_seq_no <= self.replica.H):
+            return STASH_WATERMARKS, OUTSIDE_WATERMARKS
 
         return PROCESS, None
 

--- a/plenum/test/batching_3pc/catch-up/test_clearing_requests_after_catchup.py
+++ b/plenum/test/batching_3pc/catch-up/test_clearing_requests_after_catchup.py
@@ -2,14 +2,14 @@ import sys
 
 import pytest
 
-from plenum.test.restart.helper import restart_nodes
+from plenum.test.batching_3pc.helper import node_caughtup
 from plenum.test.stasher import delay_rules
 
 from plenum.server.quorums import Quorum
 
 from stp_core.loop.eventually import eventually
 
-from plenum.test.delayers import cDelay, pDelay, ppDelay, msg_rep_delay, chk_delay
+from plenum.test.delayers import cDelay, pDelay, ppDelay
 from plenum.test.helper import sdk_send_batches_of_random_and_check, \
     sdk_send_batches_of_random, max_3pc_batch_limits, assertExp
 
@@ -24,10 +24,6 @@ ledger_id = 1
 another_key = 'request_2'
 
 
-def node_caughtup(node, old_count):
-    assert node.spylog.count(node.allLedgersCaughtUp) > old_count
-
-
 @pytest.fixture(scope="module")
 def tconf(tconf):
     with max_3pc_batch_limits(tconf, size=1) as tconf:
@@ -35,31 +31,6 @@ def tconf(tconf):
         tconf.METRICS_COLLECTOR_TYPE = 'kv'
         yield tconf
         tconf.METRICS_COLLECTOR_TYPE = old_type
-
-
-def test_freeing_forwarded_not_preprepared_request(
-        looper, chkFreqPatched, reqs_for_checkpoint, txnPoolNodeSet,
-        sdk_pool_handle, sdk_wallet_steward, tconf, tdir, allPluginsPath):
-    behind_node = txnPoolNodeSet[-1]
-    behind_node.requests.clear()
-
-    sdk_send_batches_of_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle,
-                                         sdk_wallet_steward, CHK_FREQ, CHK_FREQ)
-    with delay_rules(behind_node.nodeIbStasher, chk_delay(delay=sys.maxsize,
-                                                          instId=behind_node.replicas.values()[-1])):
-        with delay_rules(behind_node.nodeIbStasher,
-                         ppDelay(delay=sys.maxsize),
-                         pDelay(delay=sys.maxsize),
-                         cDelay(delay=sys.maxsize)):
-            count = behind_node.spylog.count(behind_node.allLedgersCaughtUp)
-            sdk_send_batches_of_random(looper, txnPoolNodeSet, sdk_pool_handle,
-                                       sdk_wallet_steward, req_num, req_num)
-            looper.run(eventually(node_caughtup, behind_node, count, retryWait=1))
-            looper.run(eventually(lambda: assertExp(len(behind_node.requests) == req_num)))
-
-    # We execute caughtup requests
-    looper.run(eventually(lambda: assertExp(len(behind_node.requests) == req_num)))
-    assert all(r.executed for r in behind_node.requests.values() if behind_node.seqNoDB.get(r.request.key)[1])
 
 
 def test_clearing_forwarded_preprepared_request(
@@ -86,34 +57,6 @@ def test_clearing_forwarded_preprepared_request(
     assert all([len(q) == 0 for r in behind_node.replicas.values() for q in r.requestQueues.values()])
     assert len(behind_node.clientAuthNr._verified_reqs) == 0
     assert len(behind_node.requestSender) == 0
-
-
-def test_freeing_forwarded_preprepared_request(
-        looper, chkFreqPatched, reqs_for_checkpoint, txnPoolNodeSet,
-        sdk_pool_handle, sdk_wallet_steward):
-    # Case, when both backup and primary had problems
-    behind_node = txnPoolNodeSet[-1]
-
-    sdk_send_batches_of_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle,
-                                         sdk_wallet_steward, CHK_FREQ, CHK_FREQ)
-    with delay_rules(behind_node.nodeIbStasher,
-                     pDelay(delay=sys.maxsize),
-                     cDelay(delay=sys.maxsize), ):
-        count = behind_node.spylog.count(behind_node.allLedgersCaughtUp)
-
-        sdk_send_batches_of_random(looper, txnPoolNodeSet, sdk_pool_handle,
-                                   sdk_wallet_steward, req_num, req_num)
-
-        looper.run(eventually(node_caughtup, behind_node, count, retryWait=1))
-
-    assert len(behind_node.requests) == req_num
-    assert all(r.executed for r in behind_node.requests.values() if behind_node.seqNoDB.get(r.request.key)[1])
-
-    sdk_send_batches_of_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle,
-                                         sdk_wallet_steward, CHK_FREQ, CHK_FREQ)
-
-    # Master and backup replicas do not stash new requests and succesfully order them
-    assert len(behind_node.requests) == req_num
 
 
 def test_deletion_non_forwarded_request(

--- a/plenum/test/batching_3pc/catch-up/test_freeing_forwarded_not_preprepared_request.py
+++ b/plenum/test/batching_3pc/catch-up/test_freeing_forwarded_not_preprepared_request.py
@@ -1,0 +1,57 @@
+import sys
+
+import pytest
+
+from plenum.test.batching_3pc.helper import node_caughtup
+from plenum.test.stasher import delay_rules
+
+
+from stp_core.loop.eventually import eventually
+
+from plenum.test.delayers import cDelay, pDelay, ppDelay, chk_delay
+from plenum.test.helper import sdk_send_batches_of_random_and_check, \
+    sdk_send_batches_of_random, max_3pc_batch_limits, assertExp
+
+from plenum.test.checkpoints.conftest import chkFreqPatched, reqs_for_checkpoint
+
+CHK_FREQ = 5
+LOG_SIZE = 3 * CHK_FREQ
+
+req_num = CHK_FREQ * 2
+howlong = 100
+ledger_id = 1
+another_key = 'request_2'
+
+
+@pytest.fixture(scope="module")
+def tconf(tconf):
+    with max_3pc_batch_limits(tconf, size=1) as tconf:
+        old_type = tconf.METRICS_COLLECTOR_TYPE
+        tconf.METRICS_COLLECTOR_TYPE = 'kv'
+        yield tconf
+        tconf.METRICS_COLLECTOR_TYPE = old_type
+
+
+def test_freeing_forwarded_not_preprepared_request(
+        looper, chkFreqPatched, reqs_for_checkpoint, txnPoolNodeSet,
+        sdk_pool_handle, sdk_wallet_steward, tconf, tdir, allPluginsPath):
+    behind_node = txnPoolNodeSet[-1]
+    behind_node.requests.clear()
+
+    sdk_send_batches_of_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle,
+                                         sdk_wallet_steward, CHK_FREQ, CHK_FREQ)
+    with delay_rules(behind_node.nodeIbStasher, chk_delay(delay=sys.maxsize,
+                                                          instId=behind_node.replicas.values()[-1])):
+        with delay_rules(behind_node.nodeIbStasher,
+                         ppDelay(delay=sys.maxsize),
+                         pDelay(delay=sys.maxsize),
+                         cDelay(delay=sys.maxsize)):
+            count = behind_node.spylog.count(behind_node.allLedgersCaughtUp)
+            sdk_send_batches_of_random(looper, txnPoolNodeSet, sdk_pool_handle,
+                                       sdk_wallet_steward, req_num, req_num)
+            looper.run(eventually(node_caughtup, behind_node, count, retryWait=1))
+            looper.run(eventually(lambda: assertExp(len(behind_node.requests) == req_num)))
+
+    # We execute caughtup requests
+    looper.run(eventually(lambda: assertExp(len(behind_node.requests) == req_num)))
+    assert all(r.executed for r in behind_node.requests.values() if behind_node.seqNoDB.get(r.request.key)[1])

--- a/plenum/test/batching_3pc/catch-up/test_freeing_forwarded_preprepared_request.py
+++ b/plenum/test/batching_3pc/catch-up/test_freeing_forwarded_preprepared_request.py
@@ -1,0 +1,60 @@
+import sys
+
+import pytest
+
+from plenum.test.batching_3pc.helper import node_caughtup
+from plenum.test.stasher import delay_rules
+
+from stp_core.loop.eventually import eventually
+
+from plenum.test.delayers import cDelay, pDelay
+from plenum.test.helper import sdk_send_batches_of_random_and_check, \
+    sdk_send_batches_of_random, max_3pc_batch_limits, assertExp
+
+from plenum.test.checkpoints.conftest import chkFreqPatched, reqs_for_checkpoint
+
+CHK_FREQ = 5
+LOG_SIZE = 3 * CHK_FREQ
+
+req_num = CHK_FREQ * 2
+howlong = 100
+ledger_id = 1
+another_key = 'request_2'
+
+
+@pytest.fixture(scope="module")
+def tconf(tconf):
+    with max_3pc_batch_limits(tconf, size=1) as tconf:
+        old_type = tconf.METRICS_COLLECTOR_TYPE
+        tconf.METRICS_COLLECTOR_TYPE = 'kv'
+        yield tconf
+        tconf.METRICS_COLLECTOR_TYPE = old_type
+
+
+def test_freeing_forwarded_preprepared_request(
+        looper, chkFreqPatched, reqs_for_checkpoint, txnPoolNodeSet,
+        sdk_pool_handle, sdk_wallet_steward):
+    # Case, when both backup and primary had problems
+    behind_node = txnPoolNodeSet[-1]
+
+    sdk_send_batches_of_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle,
+                                         sdk_wallet_steward, CHK_FREQ, CHK_FREQ)
+    with delay_rules(behind_node.nodeIbStasher,
+                     pDelay(delay=sys.maxsize),
+                     cDelay(delay=sys.maxsize), ):
+        count = behind_node.spylog.count(behind_node.allLedgersCaughtUp)
+
+        sdk_send_batches_of_random(looper, txnPoolNodeSet, sdk_pool_handle,
+                                   sdk_wallet_steward, req_num, req_num)
+
+        looper.run(eventually(node_caughtup, behind_node, count, retryWait=1))
+
+    looper.run(eventually(lambda: assertExp(len(behind_node.requests) == req_num)))
+    assert all(r.executed for r in behind_node.requests.values() if behind_node.seqNoDB.get(r.request.key)[1])
+
+    sdk_send_batches_of_random_and_check(looper, txnPoolNodeSet, sdk_pool_handle,
+                                         sdk_wallet_steward, CHK_FREQ, CHK_FREQ)
+
+    # Master and backup replicas do not stash new requests and succesfully order them
+    assert len(behind_node.requests) == req_num
+

--- a/plenum/test/batching_3pc/helper.py
+++ b/plenum/test/batching_3pc/helper.py
@@ -133,3 +133,7 @@ def check_uncommitteds_equal(nodes):
     assert check_if_all_equal_in_list(t_roots)
     assert check_if_all_equal_in_list(s_roots)
     return t_roots[0], s_roots[0]
+
+
+def node_caughtup(node, old_count):
+    assert node.spylog.count(node.allLedgersCaughtUp) > old_count

--- a/plenum/test/node_catchup_with_3pc/test_stashing_3pc_while_catchup_checkpoints.py
+++ b/plenum/test/node_catchup_with_3pc/test_stashing_3pc_while_catchup_checkpoints.py
@@ -9,7 +9,7 @@ from plenum.test import waits
 from plenum.test.delayers import cqDelay, cr_delay, cs_delay, reset_delays_and_process_delayeds, lsDelay, cpDelay
 from plenum.test.pool_transactions.helper import \
     disconnect_node_and_ensure_disconnected
-from plenum.test.helper import sdk_send_random_and_check, assertExp
+from plenum.test.helper import sdk_send_random_and_check, assertExp, max_3pc_batch_limits
 from plenum.test.node_catchup.helper import waitNodeDataEquality
 from plenum.test.stasher import delay_rules
 from plenum.test.test_node import checkNodesConnected
@@ -22,12 +22,11 @@ logger = getLogger()
 
 CHK_FREQ = 5
 
+
 @pytest.fixture(scope="module")
 def tconf(tconf):
-    old_btch_sz = tconf.Max3PCBatchSize
-    tconf.Max3PCBatchSize = 1
-    yield tconf
-    tconf.Max3PCBatchSize = old_btch_sz
+    with max_3pc_batch_limits(tconf, size=1) as tconf:
+        yield tconf
 
 
 def test_3pc_while_catchup_with_chkpoints(tdir, tconf,

--- a/plenum/test/node_catchup_with_3pc/test_stashing_3pc_while_catchup_checkpoints.py
+++ b/plenum/test/node_catchup_with_3pc/test_stashing_3pc_while_catchup_checkpoints.py
@@ -22,7 +22,14 @@ logger = getLogger()
 
 CHK_FREQ = 5
 
-@pytest.mark.skip("in progress")
+@pytest.fixture(scope="module")
+def tconf(tconf):
+    old_btch_sz = tconf.Max3PCBatchSize
+    tconf.Max3PCBatchSize = 1
+    yield tconf
+    tconf.Max3PCBatchSize = old_btch_sz
+
+
 def test_3pc_while_catchup_with_chkpoints(tdir, tconf,
                                           looper,
                                           chkFreqPatched,

--- a/plenum/test/replica/helper.py
+++ b/plenum/test/replica/helper.py
@@ -5,7 +5,8 @@ from plenum.test.helper import sdk_random_request_objects
 
 
 def emulate_catchup(replica, ppSeqNo=100):
-    replica.on_catch_up_finished((replica.viewNo, ppSeqNo))
+    replica.on_catch_up_finished(last_caught_up_3PC=(replica.viewNo, ppSeqNo),
+                                 master_last_ordered_3PC=replica.last_ordered_3pc)
 
 
 def emulate_select_primaries(replica):


### PR DESCRIPTION
Changes:
- allLedgersCaughtUp() refactoring
- change order of stashing in replica_stasher. Now messages append to view change or catchup stash queue. And if it does not happen, check for out of watermarks.