### PR TITLE
[INDY-1992] Adds base classes to support versioning routine

### DIFF
--- a/build-scripts/ubuntu-1604/build-3rd-parties.sh
+++ b/build-scripts/ubuntu-1604/build-3rd-parties.sh
@@ -84,3 +84,4 @@ build_from_pypi jsonpickle 0.9.6
 # TODO: add libsnappy dependency for python-rocksdb package
 build_from_pypi python-rocksdb 0.6.9
 build_from_pypi pympler 0.5
+build_from_pypi packaging 19.0

--- a/plenum/common/messages/fields.py
+++ b/plenum/common/messages/fields.py
@@ -14,7 +14,7 @@ from plenum import PLUGIN_LEDGER_IDS
 from plenum.common.constants import VALID_LEDGER_IDS, CURRENT_PROTOCOL_VERSION
 from plenum.common.plenum_protocol_version import PlenumProtocolVersion
 from plenum.common.version import (
-    InvalidVersion, DigitDotVersion, SemVerReleaseVersion
+    InvalidVersionError, DigitDotVersion, SemVerReleaseVersion
 )
 from plenum.config import BLS_MULTI_SIG_LIMIT, DATETIME_LIMIT, VERSION_FIELD_LIMIT
 
@@ -561,7 +561,7 @@ class VersionField(LimitedLengthStringField):
                     val, parts_num=self._comp_num, allow_non_stripped=False)
             else:
                 self._version_cls(val, allow_non_stripped=False)
-        except InvalidVersion as exc:
+        except InvalidVersionError as exc:
             return str(exc)
         else:
             return None

--- a/plenum/common/messages/fields.py
+++ b/plenum/common/messages/fields.py
@@ -2,18 +2,21 @@ import ipaddress
 import json
 import re
 from abc import ABCMeta, abstractmethod
-from typing import Iterable
+from typing import Iterable, Type
 
 import base58
 import dateutil
 
 from common.exceptions import PlenumTypeError, PlenumValueError
-from crypto.bls.bls_multi_signature import MultiSignatureValue
-from plenum.common.constants import VALID_LEDGER_IDS, CURRENT_PROTOCOL_VERSION
-from plenum import PLUGIN_LEDGER_IDS
-from plenum.common.plenum_protocol_version import PlenumProtocolVersion
 from common.error import error
-from plenum.config import BLS_MULTI_SIG_LIMIT, DATETIME_LIMIT
+from crypto.bls.bls_multi_signature import MultiSignatureValue
+from plenum import PLUGIN_LEDGER_IDS
+from plenum.common.constants import VALID_LEDGER_IDS, CURRENT_PROTOCOL_VERSION
+from plenum.common.plenum_protocol_version import PlenumProtocolVersion
+from plenum.common.version import (
+    InvalidVersion, DigitDotVersion, SemVerReleaseVersion
+)
+from plenum.config import BLS_MULTI_SIG_LIMIT, DATETIME_LIMIT, VERSION_FIELD_LIMIT
 
 
 class FieldValidator(metaclass=ABCMeta):
@@ -533,22 +536,35 @@ class SerializedValueField(FieldBase):
 class VersionField(LimitedLengthStringField):
     _base_types = (str,)
 
-    def __init__(self, components_number=(3,), **kwargs):
-        super().__init__(**kwargs)
+    # TODO components_number is legacy arg, will be removed,
+    # use version_cls instead
+    def __init__(
+            self,
+            version_cls: Type[DigitDotVersion] = SemVerReleaseVersion,
+            components_number: Iterable[int] = None,
+            max_length: int = VERSION_FIELD_LIMIT,
+            **kwargs
+    ):
+        super().__init__(max_length=max_length, **kwargs)
         self._comp_num = components_number
+        self._version_cls = version_cls
 
     def _specific_validation(self, val):
         lim_str_err = super()._specific_validation(val)
         if lim_str_err:
             return lim_str_err
-        parts = val.split(".")
-        if len(parts) not in self._comp_num:
-            return "version consists of {} components, but it should contain {}".format(
-                len(parts), self._comp_num)
-        for p in parts:
-            if not p.isdigit():
-                return "version component should contain only digits"
-        return None
+
+        try:
+            # TODO legacy logic support, will be removed
+            if self._comp_num:
+                DigitDotVersion(
+                    val, parts_num=self._comp_num, allow_non_stripped=False)
+            else:
+                self._version_cls(val, allow_non_stripped=False)
+        except InvalidVersion as exc:
+            return str(exc)
+        else:
+            return None
 
 
 class TxnSeqNoField(FieldBase):

--- a/plenum/common/version.py
+++ b/plenum/common/version.py
@@ -56,15 +56,15 @@ class VersionBase(metaclass=ABCMeta):
         return self.cmp(self, other) != 0
 
 
+class SourceVersion(VersionBase):
+    pass
+
+
 class PackageVersion(VersionBase):
     @property
     @abstractmethod
-    def upstream(self) -> str:
+    def upstream(self) -> SourceVersion:
         """ Upstream part of the package. """
-
-
-class SourceVersion(VersionBase):
-    pass
 
 
 class SemVerBase(VersionBase):

--- a/plenum/common/version.py
+++ b/plenum/common/version.py
@@ -1,0 +1,153 @@
+from typing import Tuple, Iterable
+from abc import abstractmethod, ABCMeta
+from packaging.version import (
+    Version as PEP440Version,
+    InvalidVersion as PEP440InvalidVersion
+)
+
+
+class InvalidVersion(ValueError):
+    pass
+
+
+class VersionBase(metaclass=ABCMeta):
+    @classmethod
+    @abstractmethod
+    def cmp(cls, v1: 'VersionBase', v2: 'VersionBase') -> int:
+        """ Compares two instances. """
+
+    @property
+    @abstractmethod
+    def full(self) -> str:
+        """ Full version string. """
+
+    @property
+    @abstractmethod
+    def parts(self) -> Iterable:
+        """ Full version as iterable. """
+
+    @property
+    @abstractmethod
+    def release(self) -> str:
+        """ Release part string. """
+
+    @property
+    @abstractmethod
+    def release_parts(self) -> Iterable:
+        """ Release part as iterable. """
+
+    def __lt__(self, other: 'VersionBase') -> bool:
+        return self.cmp(self, other) < 0
+
+    def __gt__(self, other: 'VersionBase') -> bool:
+        return self.cmp(self, other) > 0
+
+    def __eq__(self, other: 'VersionBase') -> bool:
+        return self.cmp(self, other) == 0
+
+    def __le__(self, other: 'VersionBase') -> bool:
+        return self.cmp(self, other) <= 0
+
+    def __ge__(self, other: 'VersionBase') -> bool:
+        return self.cmp(self, other) >= 0
+
+    def __ne__(self, other: 'VersionBase') -> bool:
+        return self.cmp(self, other) != 0
+
+
+class SemVerBase(VersionBase):
+    @property
+    def major(self) -> str:
+        return self.release_parts[0]
+
+    @property
+    def minor(self) -> str:
+        return self.release_parts[1]
+
+    @property
+    def patch(self) -> str:
+        return self.release_parts[2]
+
+
+# TODO tests
+class PEP440BasedVersion(VersionBase):
+
+    @classmethod
+    def cmp(cls, v1: 'PEP440BasedVersion', v2: 'PEP440BasedVersion') -> int:
+        if v1._version > v2._version:
+            return 1
+        elif v1._version == v2._version:
+            return 0
+        else:
+            return -1
+
+    def __init__(self, version: str):
+        try:
+            self._version = PEP440Version(version)
+        except PEP440InvalidVersion as exc:
+            # TODO is it the best string to pass
+            raise InvalidVersion(str(exc))
+
+        # TODO create API wrappers for dev, pre and post from PEP440Version
+
+    @property
+    def public(self) -> str:
+        return self._version.public
+
+    @property
+    def full(self) -> str:
+        res = self._version.public
+        if self._version.local:
+            res += "+{}".format(self._version.local)
+        return res
+
+    @property
+    def parts(self) -> Iterable:
+        # TODO
+        #   - API for add_parts
+        add_parts = tuple()
+        if self._version.is_devrelease:
+            add_parts = ('dev', self._version.dev)
+        elif self._version.is_prerelease:
+            add_parts = self._version.pre
+        elif self._version.is_postrelease:
+            add_parts = ('dev', self._version.post)
+        return (
+            self._version.epoch,
+            *self.release_parts,
+            *add_parts,
+            self._version.local
+        )
+
+    @property
+    def release(self) -> str:
+        return '.'.join(map(str, self.release_parts))
+
+    @property
+    def release_parts(self) -> Iterable:
+        return self._version.release
+
+
+# TODO allows (silently normalizes) leading zeroes in parts
+class SemVerReleaseVersion(PEP440BasedVersion, SemVerBase):
+    def __init__(self, version: str):
+        super().__init__(version)
+        # additional restrictions
+        if (self._version.is_devrelease or
+                self._version.is_prerelease or
+                self._version.is_postrelease or
+                self._version.epoch or
+                self._version.local or
+                len(self._version.release) != 3):
+            raise InvalidVersion("only major.minor.patch parts are expected")
+
+
+class PackageVersion(VersionBase):
+    @property
+    @abstractmethod
+    def upstream(self) -> str:
+        """ Upstream part of the package. """
+
+
+class SourceVersion(VersionBase):
+    pass

--- a/plenum/common/version.py
+++ b/plenum/common/version.py
@@ -55,6 +55,9 @@ class VersionBase(metaclass=ABCMeta):
     def __ne__(self, other: 'VersionBase') -> bool:
         return self.cmp(self, other) != 0
 
+    def __hash__(self):
+        return hash(self.full)
+
 
 class SourceVersion(VersionBase):
     pass

--- a/plenum/common/version.py
+++ b/plenum/common/version.py
@@ -7,7 +7,7 @@ from packaging.version import (
 )
 
 
-class InvalidVersion(ValueError):
+class InvalidVersionError(ValueError):
     pass
 
 
@@ -94,13 +94,15 @@ class PEP440BasedVersion(VersionBase):
 
     def __init__(self, version: str, allow_non_stripped: bool = True):
         if not allow_non_stripped and version != version.strip():
-            raise InvalidVersion('version includes leading and/or trailing spaces')
+            raise InvalidVersionError(
+                'version includes leading and/or trailing spaces'
+            )
 
         try:
             self._version = PEP440Version(version)
         except PEP440InvalidVersion as exc:
             # TODO is it the best string to pass
-            raise InvalidVersion(str(exc))
+            raise InvalidVersionError(str(exc))
 
         # TODO create API wrappers for dev, pre and post from PEP440Version
 
@@ -156,14 +158,14 @@ class DigitDotVersion(PEP440BasedVersion):
                 self._version.post or
                 self._version.epoch or
                 self._version.local):
-            raise InvalidVersion("only dots and digits are expected")
+            raise InvalidVersionError("only dots and digits are expected")
         if parts_num:
             # TODO docs for typing doesn't specify explicitly whether
             # typing.Iterable can be used instead or not
             if not isinstance(parts_num, collections.abc.Iterable):
                 parts_num = [parts_num]
             if len(self.parts) not in parts_num:
-                raise InvalidVersion(
+                raise InvalidVersionError(
                     "invalid number of parts {}, should contain {}"
                     .format(len(self.parts), ' or '.join(map(str, parts_num)))
                 )

--- a/plenum/common/version.py
+++ b/plenum/common/version.py
@@ -120,11 +120,11 @@ class PEP440BasedVersion(VersionBase):
         # TODO
         #   - API for add_parts
         add_parts = tuple()
-        if self._version.is_devrelease:
+        if self._version.dev:
             add_parts = ('dev', self._version.dev)
-        elif self._version.is_prerelease:
+        elif self._version.pre:
             add_parts = self._version.pre
-        elif self._version.is_postrelease:
+        elif self._version.post:
             add_parts = ('dev', self._version.post)
         return (
             self._version.epoch,
@@ -151,9 +151,9 @@ class DigitDotVersion(PEP440BasedVersion):
     ):
         super().__init__(version, **kwargs)
         # additional restrictions
-        if (self._version.is_devrelease or
-                self._version.is_prerelease or
-                self._version.is_postrelease or
+        if (self._version.dev or
+                self._version.pre or
+                self._version.post or
                 self._version.epoch or
                 self._version.local):
             raise InvalidVersion("only dots and digits are expected")

--- a/plenum/common/version.py
+++ b/plenum/common/version.py
@@ -81,7 +81,6 @@ class SemVerBase(VersionBase):
         return self.release_parts[2]
 
 
-# TODO tests
 class PEP440BasedVersion(VersionBase):
 
     @classmethod
@@ -143,7 +142,6 @@ class PEP440BasedVersion(VersionBase):
         return self._version.release
 
 
-# TODO tests
 class DigitDotVersion(PEP440BasedVersion):
     def __init__(
             self,

--- a/plenum/test/common/version/test_version.py
+++ b/plenum/test/common/version/test_version.py
@@ -1,0 +1,189 @@
+import pytest
+
+from plenum.common.version import (
+    InvalidVersion, VersionBase, PEP440BasedVersion,
+    SemVerBase, SemVerReleaseVersion, PackageVersion
+)
+
+
+def abc_required(properties=None, classmethods=None):
+    def _f(*_, **__):
+        pass
+
+    res = {}
+    for p in properties or []:
+        res[p] = property(_f)
+    for clm in classmethods or []:
+        res[clm] = classmethod(_f)
+    return res
+
+
+def iterate_abstracts(required, cls_name, base_cls, base_required=None):
+    for i in range(len(required)):
+        _dict = {
+            attr: f for idx, (attr, f) in
+            enumerate(required.items()) if idx <= i
+        }
+        if base_required:
+            _dict.update(base_required)
+        version_cls = type(cls_name, (base_cls,), _dict)
+        yield (version_cls, i + 1 == len(required))
+
+
+@pytest.fixture
+def version_base_required():
+    return abc_required(
+        properties=('full', 'parts', 'release', 'release_parts'),
+        classmethods=('cmp',)
+    )
+
+
+def test_version_base_abstracts(version_base_required):
+    for version_cls, filled in iterate_abstracts(
+            version_base_required,
+            'VersionBaseChild',
+            VersionBase):
+        if filled:
+            version_cls()
+        else:
+            with pytest.raises(TypeError):
+                version_cls()
+
+
+def test_version_base_comparison_operators(version_base_required):
+    def cmp(cls, v1, v2):
+        if v1.val > v2.val:
+            return 1
+        elif v1.val == v2.val:
+            return 0
+        else:
+            return -1
+
+    def init(self, val):
+        self.val = val
+
+    version_base_required['cmp'] = classmethod(cmp)
+    version_base_required['__init__'] = init
+
+    version_cls = type("VersionBaseChild", (VersionBase,), version_base_required)
+
+    assert version_cls(1) < version_cls(2)
+    assert version_cls(2) > version_cls(1)
+    assert version_cls(1) == version_cls(1)
+    assert version_cls(1) <= version_cls(2)
+    assert version_cls(2) <= version_cls(2)
+    assert version_cls(2) >= version_cls(1)
+    assert version_cls(1) >= version_cls(1)
+    assert version_cls(1) != version_cls(2)
+
+
+def test_sem_ver_base_api(version_base_required):
+    version_base_required['release_parts'] = property(lambda *_: (1, 2, 3))
+    version_cls = type("SemVerBaseChild", (SemVerBase,), version_base_required)
+    assert version_cls().major == 1
+    assert version_cls().minor == 2
+    assert version_cls().patch == 3
+
+
+# TODO do we need more test coverage here ?
+# (PEP440BasedVersion just wraps packaging package)
+
+def test_pep440_based_version_init():
+    with pytest.raises(InvalidVersion):
+        PEP440BasedVersion('a1')
+    PEP440BasedVersion('1.2.3.rc1')
+
+
+@pytest.mark.parametrize(
+    'val1,val2,res',
+    [
+        ('1.2.3', '1.2.3.rc1', 1),
+        ('1.2.3.dev2', '1.2.3.rc1', -1),
+        ('1.2.3rc1', '1.2.3.rc1', 0),
+    ]
+)
+def test_pep440_based_version_cmp(val1, val2, res):
+    assert PEP440BasedVersion.cmp(
+        PEP440BasedVersion(val1),
+        PEP440BasedVersion(val2)
+    ) == res
+
+
+def test_pep440_based_version_public():
+    assert PEP440BasedVersion('1.2.3rc1+1').public == '1.2.3rc1'
+
+
+def test_pep440_based_version_full():
+    assert PEP440BasedVersion('1!1.2.3').full == '1!1.2.3'
+    assert PEP440BasedVersion('1.2.3.dev2').full == '1.2.3.dev2'
+    assert PEP440BasedVersion('1.2.3.rc1').full == '1.2.3rc1'
+    assert PEP440BasedVersion('1.2.3rc1').full == '1.2.3rc1'
+    assert PEP440BasedVersion('1.2.3rc1+1').full == '1.2.3rc1+1'
+
+
+def test_pep440_based_version_parts():
+    assert PEP440BasedVersion('1.2.3.dev2').parts == (0, 1, 2, 3, 'dev', 2, None)
+    assert PEP440BasedVersion('1!1.2.3.rc2').parts == (1, 1, 2, 3, 'rc', 2, None)
+    assert PEP440BasedVersion('1.2.3+local').parts == (0, 1, 2, 3, 'local')
+
+
+def test_pep440_based_version_release():
+    assert PEP440BasedVersion('2!1.2.3.dev2').release == '1.2.3'
+
+
+def test_pep440_based_version_release_parts():
+    assert PEP440BasedVersion('1.2.3.dev2').release_parts == (1, 2, 3)
+
+
+# valid PEP440:
+#  devrelease
+#  alpha prerelease
+#  beta prerelease
+#  rc prerelease
+#  postrelease
+#  epoch
+#  local verion
+#  parts num != 3
+# valid SemVer:
+#  with prerelease part
+#  with build metadata
+@pytest.mark.parametrize(
+    'version',
+    [
+        '1.2.3.dev2',
+        '1.2.3a1',
+        '1.2.3b2',
+        '1.2.3rc3',
+        '1.2.3.post1',
+        '1!1.2.3',
+        '1.2.3+1',
+        '1',
+        '1.2',
+        '1.2.3.4',
+        '1.2.3-1',
+        '1.2.3+1',
+        '1.2.3-1+1',
+    ]
+)
+def test_sem_ver_release_version_invalid(version):
+    with pytest.raises(InvalidVersion):
+        SemVerReleaseVersion(version)
+
+
+def test_sem_ver_release_version_valid():
+    SemVerReleaseVersion('1.2.3')
+
+
+def test_package_version_abstracts(version_base_required):
+    package_version_required = abc_required(properties=('upstream',))
+
+    for version_cls, filled in iterate_abstracts(
+            package_version_required,
+            'PackageVersionChild',
+            PackageVersion,
+            base_required=version_base_required):
+        if filled:
+            version_cls()
+        else:
+            with pytest.raises(TypeError):
+                version_cls()

--- a/plenum/test/common/version/test_version.py
+++ b/plenum/test/common/version/test_version.py
@@ -184,7 +184,7 @@ def test_digit_dot_version_valid():
     DigitDotVersion('1.2.3.4.5', parts_num=(3, 5))
 
 
-def test_digit_dot_version_invalid_parts():
+def test_digit_dot_version_invalid_parts_num():
     with pytest.raises(InvalidVersion) as excinfo:
         DigitDotVersion('1.2.3', parts_num=4)
     assert 'should contain 4' in str(excinfo.value)

--- a/plenum/test/common/version/test_version.py
+++ b/plenum/test/common/version/test_version.py
@@ -1,7 +1,7 @@
 import pytest
 
 from plenum.common.version import (
-    InvalidVersion, VersionBase, PEP440BasedVersion,
+    InvalidVersionError, VersionBase, PEP440BasedVersion,
     SemVerBase, DigitDotVersion, SemVerReleaseVersion,
     PackageVersion
 )
@@ -91,17 +91,17 @@ def test_sem_ver_base_api(version_base_required):
 
 def test_pep440_based_version_init_stripped():
     # stripped
-    with pytest.raises(InvalidVersion):
+    with pytest.raises(InvalidVersionError):
         PEP440BasedVersion('a1')
     PEP440BasedVersion('1.2.3.rc1')
 
 
 def test_pep440_based_version_init_non_stripped():
     # non stripped
-    with pytest.raises(InvalidVersion):
+    with pytest.raises(InvalidVersionError):
         PEP440BasedVersion(' 1.2.3', allow_non_stripped=False)
 
-    with pytest.raises(InvalidVersion):
+    with pytest.raises(InvalidVersionError):
         PEP440BasedVersion('1.2.3 ', allow_non_stripped=False)
 
     PEP440BasedVersion(' 1.2.3 ', allow_non_stripped=True)
@@ -169,7 +169,7 @@ def test_pep440_based_version_release_parts():
     ]
 )
 def test_digit_dot_version_invalid_value(version):
-    with pytest.raises(InvalidVersion):
+    with pytest.raises(InvalidVersionError):
         DigitDotVersion(version)
 
 
@@ -185,15 +185,15 @@ def test_digit_dot_version_valid():
 
 
 def test_digit_dot_version_invalid_parts_num():
-    with pytest.raises(InvalidVersion) as excinfo:
+    with pytest.raises(InvalidVersionError) as excinfo:
         DigitDotVersion('1.2.3', parts_num=4)
     assert 'should contain 4' in str(excinfo.value)
 
-    with pytest.raises(InvalidVersion) as excinfo:
+    with pytest.raises(InvalidVersionError) as excinfo:
         DigitDotVersion('1.2.3', parts_num=[4, 5])
     assert 'should contain 4 or 5' in str(excinfo.value)
 
-    with pytest.raises(InvalidVersion) as excinfo:
+    with pytest.raises(InvalidVersionError) as excinfo:
         DigitDotVersion('1.2.3', parts_num=(4, 6, 7))
     assert 'should contain 4 or 6 or 7' in str(excinfo.value)
 
@@ -215,7 +215,7 @@ def test_digit_dot_version_invalid_parts_num():
     ]
 )
 def test_sem_ver_release_version_invalid(version):
-    with pytest.raises(InvalidVersion):
+    with pytest.raises(InvalidVersionError):
         SemVerReleaseVersion(version)
 
 

--- a/plenum/test/input_validation/fields_validation/test_version_field.py
+++ b/plenum/test/input_validation/fields_validation/test_version_field.py
@@ -1,44 +1,61 @@
 import pytest
 
+from plenum.common.version import DigitDotVersion
 from plenum.common.messages.fields import VersionField
 from plenum.config import VERSION_FIELD_LIMIT
 
-validator = VersionField(components_number=(2, 3,), max_length=VERSION_FIELD_LIMIT)
+
+class VersionTestCls(DigitDotVersion):
+    def __init__(self, version: str, **kwargs):
+        super().__init__(version, parts_num=(2, 3), **kwargs)
 
 
-def test_empty_version():
+max_length = 20
+legacy_validator = VersionField(components_number=(2, 3,), max_length=max_length)
+validator = VersionField(version_cls=VersionTestCls, max_length=max_length)
+
+
+@pytest.fixture(
+    params=(legacy_validator, validator),
+    ids=('legacy', 'actual')
+)
+def validator(request):
+    return request.param
+
+
+def test_empty_version(validator):
     assert validator.validate('')
 
 
-def test_valid_version():
+def test_valid_version(validator):
     assert not validator.validate('1.2.3')
     assert not validator.validate('0.2.0')
     assert not validator.validate('0.2')
 
 
-def test_one_component_fails():
+def test_one_component_fails(validator):
     assert validator.validate('123')
 
 
-def test_a_string_component_fails():
+def test_a_string_component_fails(validator):
     assert validator.validate('asdf.asdf')
 
 
-def test_invalid_version():
+def test_invalid_version(validator):
     assert validator.validate('123.ads.00')
 
 
-def test_invalid_number_of_comp():
+def test_invalid_number_of_comp(validator):
     assert validator.validate('1.2.3.4')
 
 
-def test_invalid_negative_comp():
+def test_invalid_negative_comp(validator):
     assert validator.validate('-1.-2.-3')
     assert validator.validate('-1.2.3')
     assert validator.validate('1.2.-3')
 
 
-def test_spaces():
+def test_spaces(validator):
     assert validator.validate(' 1.2.3')
     assert validator.validate('1. 2.3')
     assert validator.validate('1.2. 3')
@@ -53,7 +70,7 @@ def test_spaces():
     assert validator.validate('1.2.-3 ')
 
 
-def test_max_length_limit():
+def test_max_length_limit(validator):
     assert validator.validate("1" * (VERSION_FIELD_LIMIT + 1))
     assert validator.validate("{}.{}".format("1" * (VERSION_FIELD_LIMIT + 1), "2"))
     assert validator.validate("{}.{}".format("2", "1" * (VERSION_FIELD_LIMIT + 1)))

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
                       'six==1.11.0', 'psutil==5.4.3', 'intervaltree==2.1.0',
                       'msgpack-python==0.4.6', 'indy-crypto==0.4.5',
                       'python-rocksdb==0.6.9', 'python-dateutil==2.6.1',
-                      'pympler==0.5'],
+                      'pympler==0.5', 'packaging==19.0'],
     setup_requires=['pytest-runner'],
     extras_require={
         'tests': tests_require,


### PR DESCRIPTION
Changes:

- classes to abstract version API
- update for version field validation
- new dependency `packaging==19.0` to support PEP440 (PyPI versioning)