### PR TITLE
[INDY-2103] Minor changes to how exception formating is done

### DIFF
--- a/plenum/common/exceptions.py
+++ b/plenum/common/exceptions.py
@@ -55,6 +55,9 @@ class CouldNotAuthenticate(SigningException, ReqInfo):
         self.reason = self.reason.format(identifier)
         ReqInfo.__init__(self, *args, **kwargs)
 
+    def __str__(self):
+        return self.reason
+
 
 class MissingSignature(SigningException):
     code = 120
@@ -93,6 +96,9 @@ class InsufficientSignatures(SigningException, ReqInfo):
         self.reason = self.reason.format(provided, required)
         ReqInfo.__init__(self, *args, **kwargs)
 
+    def __str__(self):
+        return self.reason
+
 
 class InsufficientCorrectSignatures(SigningException, ReqInfo):
     code = 127
@@ -105,6 +111,9 @@ class InsufficientCorrectSignatures(SigningException, ReqInfo):
         invalid_sigs_str = '; '.join('did={}, signature={}'.format(k, v) for k, v in invalid_sigs.items())
         self.reason = self.reason.format(required_sig_cnt, valid_sig_cnt, len(invalid_sigs), invalid_sigs_str)
         ReqInfo.__init__(self, *args, **kwargs)
+
+    def __str__(self):
+        return self.reason
 
 
 class MissingIdentifier(SigningException):

--- a/plenum/common/util.py
+++ b/plenum/common/util.py
@@ -371,7 +371,7 @@ def friendlyEx(ex: Exception) -> str:
         if len(friendly):
             friendly += " [caused by "
             end += "]"
-        friendly += "{}".format(getattr(curEx, 'reason', curEx))
+        friendly += "{}".format(curEx)
         curEx = curEx.__cause__
     friendly += end
     return friendly

--- a/plenum/test/blacklist/test_blacklist_client.py
+++ b/plenum/test/blacklist/test_blacklist_client.py
@@ -25,7 +25,7 @@ def testDoNotBlacklistClient(looper, txnPoolNodeSet,
 
     reqs = sdk_send_signed_requests(sdk_pool_handle, [json.dumps(req_obj.as_dict)])
 
-    with pytest.raises(RequestNackedException, match='missing signature'):
+    with pytest.raises(RequestNackedException, match='MissingSignature'):
         sdk_get_and_check_replies(looper, reqs)
 
     def chk():

--- a/plenum/test/client/test_client.py
+++ b/plenum/test/client/test_client.py
@@ -57,7 +57,7 @@ def testSendRequestWithoutSignatureFails(looper, txnPoolNodeSet,
         (msg, frm) = params["msg"]
         assert msg == json_req
         assert msg.get(f.IDENTIFIER.nm) == obj_req.identifier
-        assert "missing signature" in reason
+        assert "MissingSignature" in reason
 
 
 # noinspection PyIncorrectDocstring

--- a/plenum/test/util/test_common_util.py
+++ b/plenum/test/util/test_common_util.py
@@ -13,7 +13,7 @@ def test_random_string():
     assert False
 
 
-def test_friendly_exception_formatting_exception_without_reason_field():
+def test_friendly_exception_formatting_exc_without_str_overload():
     """
         Check if the `friendyEx` is formatting exceptions without a reason field correctly
     """
@@ -24,7 +24,7 @@ def test_friendly_exception_formatting_exception_without_reason_field():
     assert formatted_exception == '{}'.format(ex)
 
 
-def test_friendly_exception_formatting_exception_with_reason_field():
+def test_friendly_exception_formatting_exc_with_str_overload():
     """
         Check if the `friendyEx` is formatting exceptions with a reason field correctly
     """
@@ -32,7 +32,7 @@ def test_friendly_exception_formatting_exception_with_reason_field():
 
     formatted_exception = friendlyEx(ex)
 
-    assert formatted_exception == ex.reason
+    assert formatted_exception == '{}'.format(ex)
 
 
 def test_friendly_exception_formatting_multiple_exceptions():
@@ -45,7 +45,7 @@ def test_friendly_exception_formatting_multiple_exceptions():
     ex3 = SigningException()
     ex3.__cause__ = ex2
 
-    expected = '{} [caused by {} [caused by {}]]'.format('SigningException()', ex2.reason, ex1.reason)
+    expected = '{} [caused by {} [caused by {}]]'.format(ex3, ex2, ex1)
     formatted_exception = friendlyEx(ex3)
 
     assert formatted_exception == expected

--- a/plenum/test/util/test_common_util.py
+++ b/plenum/test/util/test_common_util.py
@@ -32,7 +32,7 @@ def test_friendly_exception_formatting_exc_with_str_overload():
 
     formatted_exception = friendlyEx(ex)
 
-    assert formatted_exception == '{}'.format(ex)
+    assert formatted_exception == '{}'.format(ex.reason)
 
 
 def test_friendly_exception_formatting_multiple_exceptions():
@@ -45,7 +45,7 @@ def test_friendly_exception_formatting_multiple_exceptions():
     ex3 = SigningException()
     ex3.__cause__ = ex2
 
-    expected = '{} [caused by {} [caused by {}]]'.format(ex3, ex2, ex1)
+    expected = '{} [caused by {} [caused by {}]]'.format(ex3, ex2.reason, ex1.reason)
     formatted_exception = friendlyEx(ex3)
 
     assert formatted_exception == expected


### PR DESCRIPTION
In order not to break how certain exceptions work now,
the scope of new formating is now contained to only some
exception types.

Signed-off-by: Nemanja Patrnogic <patrnogicnemanja@gmail.com>