### PR TITLE
INDY-1340: pp_view_no (original view no) support in BatchID

### DIFF
--- a/plenum/common/messages/fields.py
+++ b/plenum/common/messages/fields.py
@@ -707,11 +707,12 @@ class BatchIDField(FieldBase):
     _base_types = (list, tuple)
 
     def _specific_validation(self, val):
-        if len(val) != 3:
-            return 'should have size of 3'
+        if len(val) != 4:
+            return 'should have size of 4'
 
-        view_no, pp_seq_no, pp_digest = val
+        view_no, pp_view_no, pp_seq_no, pp_digest = val
         for validator, value in ((NonNegativeNumberField().validate, view_no),
+                                 (NonNegativeNumberField().validate, pp_view_no),
                                  (NonNegativeNumberField().validate, pp_seq_no),
                                  (NonEmptyStringField().validate, pp_digest)):
             err = validator(value)

--- a/plenum/common/messages/node_messages.py
+++ b/plenum/common/messages/node_messages.py
@@ -171,6 +171,7 @@ class Commit(MessageBase):
         (f.PP_SEQ_NO.nm, NonNegativeNumberField()),
         (f.BLS_SIG.nm, LimitedLengthStringField(max_length=BLS_SIG_LIMIT,
                                                 optional=True)),
+
         # PLUGIN_FIELDS is not used in Commit as of now but adding for
         # consistency
         (f.PLUGIN_FIELDS.nm, AnyMapField(optional=True, nullable=True))

--- a/plenum/server/consensus/consensus_shared_data.py
+++ b/plenum/server/consensus/consensus_shared_data.py
@@ -19,7 +19,7 @@ from plenum.server.quorums import Quorums
 BatchID = NamedTuple('BatchID', [('view_no', int), ('pp_view_no', int), ('pp_seq_no', int), ('pp_digest', str)])
 
 
-def preprepare_to_batch_id(view_no:int, pre_prepare: PrePrepare) -> BatchID:
+def preprepare_to_batch_id(view_no: int, pre_prepare: PrePrepare) -> BatchID:
     return BatchID(view_no, pre_prepare.viewNo, pre_prepare.ppSeqNo, pre_prepare.digest)
 
 

--- a/plenum/server/consensus/consensus_shared_data.py
+++ b/plenum/server/consensus/consensus_shared_data.py
@@ -8,11 +8,19 @@ from plenum.common.startable import Mode
 from plenum.server.propagator import Requests
 from plenum.server.quorums import Quorums
 
-BatchID = NamedTuple('BatchID', [('view_no', int), ('pp_seq_no', int), ('pp_digest', str)])
+# `view_no` is a view no is the current view_no, but `pp_view_no` is a view no when the given PrePrepare has been
+# initially created and applied
+
+# it's critical to keep the original view no to correctly create audit ledger transaction
+# (since PrePrepare's view no is present there)
+
+# An example when `view_no` != `pp_view_no`, is when view change didn't finish at first round
+# (next primary is unavailable for example)
+BatchID = NamedTuple('BatchID', [('view_no', int), ('pp_view_no', int), ('pp_seq_no', int), ('pp_digest', str)])
 
 
-def preprepare_to_batch_id(pre_prepare: PrePrepare) -> BatchID:
-    return BatchID(pre_prepare.viewNo, pre_prepare.ppSeqNo, pre_prepare.digest)
+def preprepare_to_batch_id(view_no:int, pre_prepare: PrePrepare) -> BatchID:
+    return BatchID(view_no, pre_prepare.viewNo, pre_prepare.ppSeqNo, pre_prepare.digest)
 
 
 class ConsensusSharedData:

--- a/plenum/server/consensus/view_change_service.py
+++ b/plenum/server/consensus/view_change_service.py
@@ -437,6 +437,9 @@ class NewViewBuilder:
                 some_bid = BatchID(*_some_bid)
                 if some_bid.pp_seq_no != bid.pp_seq_no:
                     continue
+
+                if some_bid.pp_view_no != bid.pp_view_no:
+                    return False
                 # not ( (v' < v) OR (v'==v and d'==d) )
                 if some_bid.view_no > bid.view_no:
                     return False
@@ -452,6 +455,8 @@ class NewViewBuilder:
             for _some_bid in vc.preprepared:
                 some_bid = BatchID(*_some_bid)
                 if some_bid.pp_seq_no != bid.pp_seq_no:
+                    continue
+                if some_bid.pp_view_no != bid.pp_view_no:
                     continue
                 if some_bid.pp_digest != bid.pp_digest:
                     continue

--- a/plenum/server/consensus/view_change_service.py
+++ b/plenum/server/consensus/view_change_service.py
@@ -337,7 +337,7 @@ class NewViewBuilder:
                 if some_bid.pp_seq_no != bid.pp_seq_no:
                     continue
 
-                # not ( (v' < v) OR (v'==v and d'==d) )
+                # not ( (v' < v) OR (v'==v and d'==d and pp_view_no'==pp_view_no) )
                 if some_bid.view_no > bid.view_no:
                     return False
                 if some_bid.view_no >= bid.view_no and some_bid.pp_digest != bid.pp_digest:

--- a/plenum/server/consensus/view_change_service.py
+++ b/plenum/server/consensus/view_change_service.py
@@ -26,107 +26,6 @@ def view_change_digest(msg: ViewChange) -> str:
     return sha256(serialized).hexdigest()
 
 
-class ViewChangeVotesForNode:
-    """
-    Storage for view change vote from some node for some view + corresponding acks
-    """
-
-    def __init__(self, quorums: Quorums):
-        self._quorums = quorums
-        self._view_change = None
-        self._digest = None
-        self._acks = defaultdict(set)  # Dict[str, Set[str]]
-
-    @property
-    def digest(self) -> Optional[str]:
-        """
-        Returns digest of received view change message
-        """
-        return self._digest
-
-    @property
-    def view_change(self) -> Optional[ViewChange]:
-        """
-        Returns received view change
-        """
-        return self._view_change
-
-    @property
-    def is_confirmed(self) -> bool:
-        """
-        Returns True if received view change message and enough corresponding acks
-        """
-        if self._digest is None:
-            return False
-
-        return self._quorums.view_change_ack.is_reached(len(self._acks[self._digest]))
-
-    def add_view_change(self, msg: ViewChange) -> bool:
-        """
-        Adds view change vote and returns boolean indicating if it found node suspicios
-        """
-        if self._view_change is None:
-            self._view_change = msg
-            self._digest = view_change_digest(msg)
-            return self._validate_acks()
-
-        return self._digest == view_change_digest(msg)
-
-    def add_view_change_ack(self, msg: ViewChangeAck, frm: str) -> bool:
-        """
-        Adds view change ack and returns boolean indicating if it found node suspicios
-        """
-        self._acks[msg.digest].add(frm)
-        return self._validate_acks()
-
-    def _validate_acks(self) -> bool:
-        digests = [digest for digest, acks in self._acks.items()
-                   if self._quorums.weak.is_reached(len(acks))]
-
-        if len(digests) > 1:
-            return False
-
-        if len(digests) < 1 or self._digest is None:
-            return True
-
-        return self._digest == digests[0]
-
-
-class ViewChangeVotesForView:
-    """
-    Storage for view change votes for some view + corresponding acks
-    """
-
-    def __init__(self, quorums: Quorums):
-        self._quorums = quorums
-        self._votes = defaultdict(partial(ViewChangeVotesForNode, quorums))
-
-    @property
-    def confirmed_votes(self) -> List[Tuple[str, str]]:
-        return [(frm, node_votes.digest) for frm, node_votes in self._votes.items()
-                if node_votes.is_confirmed]
-
-    def get_view_change(self, frm: str, digest: str) -> Optional[ViewChange]:
-        vc = self._votes[frm].view_change
-        if vc is not None and view_change_digest(vc) == digest:
-            return vc
-
-    def add_view_change(self, msg: ViewChange, frm: str) -> bool:
-        """
-        Adds view change ack and returns boolean indicating if it found node suspicios
-        """
-        return self._votes[frm].add_view_change(msg)
-
-    def add_view_change_ack(self, msg: ViewChangeAck, frm: str) -> bool:
-        """
-        Adds view change ack and returns boolean indicating if it found node suspicios
-        """
-        return self._votes[msg.name].add_view_change_ack(msg, frm)
-
-    def clear(self):
-        self._votes.clear()
-
-
 class ViewChangeService:
     def __init__(self, data: ConsensusSharedData, timer: TimerService, bus: InternalBus, network: ExternalBus,
                  stasher: StashingRouter):
@@ -438,13 +337,14 @@ class NewViewBuilder:
                 if some_bid.pp_seq_no != bid.pp_seq_no:
                     continue
 
-                if some_bid.pp_view_no != bid.pp_view_no:
-                    return False
                 # not ( (v' < v) OR (v'==v and d'==d) )
                 if some_bid.view_no > bid.view_no:
                     return False
                 if some_bid.view_no >= bid.view_no and some_bid.pp_digest != bid.pp_digest:
                     return False
+                if some_bid.view_no >= bid.view_no and some_bid.pp_view_no != bid.pp_view_no:
+                    return False
+
             return True
 
         prepared_witnesses = sum(1 for vc in vcs if check(vc))
@@ -481,3 +381,104 @@ class NewViewBuilder:
 
         null_batch_witnesses = sum(1 for vc in vcs if check(vc))
         return self._data.quorums.strong.is_reached(null_batch_witnesses)
+
+
+class ViewChangeVotesForNode:
+    """
+    Storage for view change vote from some node for some view + corresponding acks
+    """
+
+    def __init__(self, quorums: Quorums):
+        self._quorums = quorums
+        self._view_change = None
+        self._digest = None
+        self._acks = defaultdict(set)  # Dict[str, Set[str]]
+
+    @property
+    def digest(self) -> Optional[str]:
+        """
+        Returns digest of received view change message
+        """
+        return self._digest
+
+    @property
+    def view_change(self) -> Optional[ViewChange]:
+        """
+        Returns received view change
+        """
+        return self._view_change
+
+    @property
+    def is_confirmed(self) -> bool:
+        """
+        Returns True if received view change message and enough corresponding acks
+        """
+        if self._digest is None:
+            return False
+
+        return self._quorums.view_change_ack.is_reached(len(self._acks[self._digest]))
+
+    def add_view_change(self, msg: ViewChange) -> bool:
+        """
+        Adds view change vote and returns boolean indicating if it found node suspicios
+        """
+        if self._view_change is None:
+            self._view_change = msg
+            self._digest = view_change_digest(msg)
+            return self._validate_acks()
+
+        return self._digest == view_change_digest(msg)
+
+    def add_view_change_ack(self, msg: ViewChangeAck, frm: str) -> bool:
+        """
+        Adds view change ack and returns boolean indicating if it found node suspicios
+        """
+        self._acks[msg.digest].add(frm)
+        return self._validate_acks()
+
+    def _validate_acks(self) -> bool:
+        digests = [digest for digest, acks in self._acks.items()
+                   if self._quorums.weak.is_reached(len(acks))]
+
+        if len(digests) > 1:
+            return False
+
+        if len(digests) < 1 or self._digest is None:
+            return True
+
+        return self._digest == digests[0]
+
+
+class ViewChangeVotesForView:
+    """
+    Storage for view change votes for some view + corresponding acks
+    """
+
+    def __init__(self, quorums: Quorums):
+        self._quorums = quorums
+        self._votes = defaultdict(partial(ViewChangeVotesForNode, quorums))
+
+    @property
+    def confirmed_votes(self) -> List[Tuple[str, str]]:
+        return [(frm, node_votes.digest) for frm, node_votes in self._votes.items()
+                if node_votes.is_confirmed]
+
+    def get_view_change(self, frm: str, digest: str) -> Optional[ViewChange]:
+        vc = self._votes[frm].view_change
+        if vc is not None and view_change_digest(vc) == digest:
+            return vc
+
+    def add_view_change(self, msg: ViewChange, frm: str) -> bool:
+        """
+        Adds view change ack and returns boolean indicating if it found node suspicios
+        """
+        return self._votes[frm].add_view_change(msg)
+
+    def add_view_change_ack(self, msg: ViewChangeAck, frm: str) -> bool:
+        """
+        Adds view change ack and returns boolean indicating if it found node suspicios
+        """
+        return self._votes[msg.name].add_view_change_ack(msg, frm)
+
+    def clear(self):
+        self._votes.clear()

--- a/plenum/server/replica.py
+++ b/plenum/server/replica.py
@@ -39,7 +39,7 @@ from plenum.server.consensus.consensus_shared_data import ConsensusSharedData
 from plenum.server.consensus.ordering_service import OrderingService
 from plenum.server.has_action_queue import HasActionQueue
 from plenum.server.replica_freshness_checker import FreshnessChecker
-from plenum.server.replica_helper import replica_batch_digest
+from plenum.server.replica_helper import replica_batch_digest, TPCStat
 from plenum.server.replica_validator import ReplicaValidator
 from plenum.server.replica_validator_enums import STASH_VIEW, STASH_CATCH_UP
 from plenum.server.router import Router

--- a/plenum/server/replica.py
+++ b/plenum/server/replica.py
@@ -27,25 +27,23 @@ from plenum.common.exceptions import SuspiciousNode
 from plenum.common.message_processor import MessageProcessor
 from plenum.common.messages.internal_messages import NeedBackupCatchup, CheckpointStabilized, RaisedSuspicion
 from plenum.common.messages.message_base import MessageBase
-from plenum.common.messages.node_messages import Reject, Ordered, \
-    PrePrepare, Prepare, Commit, Checkpoint, ThreePhaseMsg, ThreePhaseKey
+from plenum.common.messages.node_messages import Ordered, \
+    PrePrepare, Prepare, Commit, ThreePhaseKey
 from plenum.common.metrics_collector import NullMetricsCollector, MetricsCollector, MetricsName
-from plenum.common.request import Request, ReqKey
+from plenum.common.request import ReqKey
 from plenum.common.router import Subscription
 from plenum.common.stashing_router import StashingRouter
-from plenum.common.util import updateNamedTuple, compare_3PC_keys
+from plenum.common.util import compare_3PC_keys
 from plenum.server.consensus.checkpoint_service import CheckpointService
-from plenum.server.consensus.consensus_shared_data import ConsensusSharedData, preprepare_to_batch_id
+from plenum.server.consensus.consensus_shared_data import ConsensusSharedData
 from plenum.server.consensus.ordering_service import OrderingService
 from plenum.server.has_action_queue import HasActionQueue
-from plenum.server.models import Commits, Prepares
 from plenum.server.replica_freshness_checker import FreshnessChecker
-from plenum.server.replica_helper import replica_batch_digest, TPCStat
-from plenum.server.replica_stasher import ReplicaStasher
+from plenum.server.replica_helper import replica_batch_digest
 from plenum.server.replica_validator import ReplicaValidator
-from plenum.server.replica_validator_enums import STASH_VIEW, STASH_WATERMARKS, STASH_CATCH_UP
+from plenum.server.replica_validator_enums import STASH_VIEW, STASH_CATCH_UP
 from plenum.server.router import Router
-from sortedcontainers import SortedList, SortedListWithKey
+from sortedcontainers import SortedList
 from stp_core.common.log import getlogger
 
 import plenum.server.node

--- a/plenum/server/replica_helper.py
+++ b/plenum/server/replica_helper.py
@@ -3,12 +3,6 @@ from collections import OrderedDict, defaultdict
 from enum import IntEnum, unique
 from typing import List
 
-from sortedcontainers import SortedListWithKey
-
-from common.exceptions import LogicError
-from plenum.common.messages.node_messages import PrePrepare, Checkpoint
-from plenum.server.consensus.consensus_shared_data import ConsensusSharedData, preprepare_to_batch_id
-
 PP_CHECK_NOT_FROM_PRIMARY = 0
 PP_CHECK_TO_PRIMARY = 1
 PP_CHECK_DUPLICATE = 2

--- a/plenum/test/audit_ledger/test_primaries_in_ordered.py
+++ b/plenum/test/audit_ledger/test_primaries_in_ordered.py
@@ -9,7 +9,7 @@ def test_primaries_in_ordered_from_audit(test_node):
     replica = test_node.master_replica
     key = (pre_prepare.viewNo, pre_prepare.ppSeqNo)
     replica._ordering_service.prePrepares[key] = pre_prepare
-    replica._consensus_data.preprepared.append(preprepare_to_batch_id(pre_prepare))
+    replica._consensus_data.preprepared.append(preprepare_to_batch_id(pre_prepare.viewNo, pre_prepare))
     test_node.primaries = ["Alpha", "Beta"]
     three_pc_batch = ThreePcBatch.from_pre_prepare(pre_prepare=pre_prepare,
                                                    state_root=pre_prepare.stateRootHash,
@@ -34,7 +34,7 @@ def test_primaries_in_ordered_from_audit_for_tree_txns(test_node):
                                        pp_seq_no=i)
         key = (pp.viewNo, pp.ppSeqNo)
         replica._ordering_service.prePrepares[key] = pp
-        replica._consensus_data.preprepared.append(preprepare_to_batch_id(pp))
+        replica._consensus_data.preprepared.append(preprepare_to_batch_id(pp.viewNo, pp))
         three_pc_batch = ThreePcBatch.from_pre_prepare(pre_prepare=pp,
                                                        state_root=pp.stateRootHash,
                                                        txn_root=pp.txnRootHash,
@@ -61,7 +61,7 @@ def test_primaries_in_ordered_from_node(test_node):
     test_node.primaries = ["Alpha", "Beta"]
     replica = test_node.master_replica
     replica._ordering_service.prePrepares[key] = pre_prepare
-    replica._consensus_data.preprepared.append(preprepare_to_batch_id(pre_prepare))
+    replica._consensus_data.preprepared.append(preprepare_to_batch_id(pre_prepare.viewNo, pre_prepare))
 
     replica._ordering_service._order_3pc_key(key)
 

--- a/plenum/test/consensus/checkpoint_service/test_checkpoint_service_unit.py
+++ b/plenum/test/consensus/checkpoint_service/test_checkpoint_service_unit.py
@@ -146,7 +146,7 @@ def test_process_checkpoint(checkpoint_service, checkpoint, pre_prepare, tconf, 
     pre_prepare.auditTxnRootHash = cp_digest(till_seq_no)
     ordered.ppSeqNo = pre_prepare.ppSeqNo
     ordered.auditTxnRootHash = pre_prepare.auditTxnRootHash
-    checkpoint_service._data.preprepared.append(preprepare_to_batch_id(pre_prepare))
+    checkpoint_service._data.preprepared.append(preprepare_to_batch_id(pre_prepare.viewNo, pre_prepare))
     checkpoint_service.process_ordered(ordered)
 
     _check_checkpoint(checkpoint_service, till_seq_no, pre_prepare, check_shared_data=True)
@@ -179,19 +179,19 @@ def test_process_ordered(checkpoint_service, ordered, pre_prepare, tconf):
                                          "ppSeqNo {} not in preprepared".format(ordered.ppSeqNo)):
         checkpoint_service.process_ordered(ordered)
 
-    checkpoint_service._data.preprepared.append(preprepare_to_batch_id(pre_prepare))
+    checkpoint_service._data.preprepared.append(preprepare_to_batch_id(pre_prepare.viewNo, pre_prepare))
     checkpoint_service.process_ordered(ordered)
     _check_checkpoint(checkpoint_service, tconf.CHK_FREQ, pre_prepare)
 
     pre_prepare.ppSeqNo = tconf.CHK_FREQ
     ordered.ppSeqNo = pre_prepare.ppSeqNo
-    checkpoint_service._data.preprepared.append(preprepare_to_batch_id(pre_prepare))
+    checkpoint_service._data.preprepared.append(preprepare_to_batch_id(pre_prepare.viewNo, pre_prepare))
     checkpoint_service.process_ordered(ordered)
     _check_checkpoint(checkpoint_service, tconf.CHK_FREQ, pre_prepare, check_shared_data=True)
 
     pre_prepare.ppSeqNo += 1
     ordered.ppSeqNo = pre_prepare.ppSeqNo
-    checkpoint_service._data.preprepared.append(preprepare_to_batch_id(pre_prepare))
+    checkpoint_service._data.preprepared.append(preprepare_to_batch_id(pre_prepare.viewNo, pre_prepare))
     checkpoint_service.process_ordered(ordered)
     _check_checkpoint(checkpoint_service, tconf.CHK_FREQ * 2, pre_prepare)
 

--- a/plenum/test/consensus/helper.py
+++ b/plenum/test/consensus/helper.py
@@ -122,9 +122,9 @@ def create_checkpoints(view_no):
 
 
 def create_batches(view_no):
-    return [BatchID(view_no, 11, "d1"),
-            BatchID(view_no, 12, "d2"),
-            BatchID(view_no, 13, "d3")]
+    return [BatchID(view_no, view_no, 11, "d1"),
+            BatchID(view_no, view_no, 12, "d2"),
+            BatchID(view_no, view_no, 13, "d3")]
 
 
 def create_view_change(initial_view_no, stable_cp=10, batches=None):

--- a/plenum/test/consensus/order_service/test_ordering_service_on_view_change.py
+++ b/plenum/test/consensus/order_service/test_ordering_service_on_view_change.py
@@ -116,12 +116,13 @@ def test_do_nothing_on_new_view_accepted(internal_bus, orderer):
     assert old_data == new_data
 
 
-def test_update_shared_data_on_mew_view_checkpoint_applied(internal_bus, orderer):
+def test_update_shared_data_on_new_view_checkpoint_applied(internal_bus, orderer):
+    initial_view_no = 3
     orderer._data.preprepared = []
     orderer._data.prepared = []
+    orderer._data.view_no = initial_view_no + 1
     old_data = copy_shared_data(orderer._data)
 
-    initial_view_no = 3
     new_view = create_new_view(initial_view_no=initial_view_no, stable_cp=200)
     internal_bus.send(NewViewCheckpointsApplied(view_no=initial_view_no + 1,
                                                 view_changes=new_view.viewChanges,
@@ -134,8 +135,8 @@ def test_update_shared_data_on_mew_view_checkpoint_applied(internal_bus, orderer
     # preprepared are created for new view
     if orderer.is_master:
         assert orderer._data.preprepared
-        assert orderer._data.preprepared == [BatchID(view_no=initial_view_no + 1, pp_seq_no=batch_id.pp_seq_no,
-                                                     pp_digest=batch_id.pp_digest)
+        assert orderer._data.preprepared == [BatchID(view_no=initial_view_no + 1, pp_view_no=initial_view_no,
+                                                     pp_seq_no=batch_id.pp_seq_no, pp_digest=batch_id.pp_digest)
                                              for batch_id in new_view.batches]
         assert orderer._data.prepared == []
     else:

--- a/plenum/test/consensus/view_change/helper.py
+++ b/plenum/test/consensus/view_change/helper.py
@@ -23,7 +23,7 @@ def some_pool(random: SimRandom) -> (SimPool, List):
     faulty = (pool_size - 1) // 3
     seq_no_per_cp = 10
     max_batches = 50
-    batches = [BatchID(0, n, random.string(40)) for n in range(1, max_batches)]
+    batches = [BatchID(0, 0, n, random.string(40)) for n in range(1, max_batches)]
     checkpoints = [some_checkpoint(random, 0, n) for n in range(0, max_batches, seq_no_per_cp)]
 
     # Preprepares
@@ -50,7 +50,7 @@ def some_pool(random: SimRandom) -> (SimPool, List):
         has_prepared_cert = prepare_count >= pool_size - faulty
         if has_prepared_cert:
             batch_id = batches[i - 1]
-            committed.append(BatchID(1, batch_id.pp_seq_no, batch_id.pp_digest))
+            committed.append(BatchID(1, 1, batch_id.pp_seq_no, batch_id.pp_digest))
 
     return pool, committed
 
@@ -59,7 +59,7 @@ def calc_committed(view_changes, max_pp_seq_no, n, f) -> List[BatchID]:
     def check_in_batch(batch_id, some_batch_id, check_view_no=False):
         if check_view_no and (batch_id[0] != some_batch_id[0]):
             return False
-        return batch_id[1] == some_batch_id[1] and batch_id[2] == some_batch_id[2]
+        return batch_id[1] == some_batch_id[1] and batch_id[2] == some_batch_id[2] and batch_id[3] == some_batch_id[3]
 
     def check_prepared_in_vc(vc, batch_id):
         # check that (pp_seq_no, digest) is present in VC's prepared and preprepared
@@ -75,7 +75,7 @@ def calc_committed(view_changes, max_pp_seq_no, n, f) -> List[BatchID]:
     def find_batch_id(pp_seq_no):
         for vc in view_changes:
             for batch_id in vc.prepared:
-                if batch_id[1] != pp_seq_no:
+                if batch_id[2] != pp_seq_no:
                     continue
                 prepared_count = sum(1 for vc in view_changes if check_prepared_in_vc(vc, batch_id))
                 if prepared_count < n - f:

--- a/plenum/test/consensus/view_change/helper.py
+++ b/plenum/test/consensus/view_change/helper.py
@@ -50,24 +50,20 @@ def some_pool(random: SimRandom) -> (SimPool, List):
         has_prepared_cert = prepare_count >= pool_size - faulty
         if has_prepared_cert:
             batch_id = batches[i - 1]
-            committed.append(BatchID(1, 1, batch_id.pp_seq_no, batch_id.pp_digest))
+            committed.append(BatchID(1, 0, batch_id.pp_seq_no, batch_id.pp_digest))
 
     return pool, committed
 
 
 def calc_committed(view_changes, max_pp_seq_no, n, f) -> List[BatchID]:
-    def check_in_batch(batch_id, some_batch_id, check_view_no=False):
-        if check_view_no and (batch_id[0] != some_batch_id[0]):
-            return False
-        return batch_id[1] == some_batch_id[1] and batch_id[2] == some_batch_id[2] and batch_id[3] == some_batch_id[3]
 
     def check_prepared_in_vc(vc, batch_id):
-        # check that (pp_seq_no, digest) is present in VC's prepared and preprepared
+        # check that batch_id is present in VC's prepared and preprepared
         for p_batch_id in vc.prepared:
-            if not check_in_batch(batch_id, p_batch_id, check_view_no=True):
+            if batch_id != p_batch_id:
                 continue
             for pp_batch_id in vc.preprepared:
-                if check_in_batch(batch_id, pp_batch_id, check_view_no=True):
+                if batch_id == pp_batch_id:
                     return True
 
         return False

--- a/plenum/test/consensus/view_change/test_new_view_builder.py
+++ b/plenum/test/consensus/view_change/test_new_view_builder.py
@@ -11,6 +11,7 @@ from plenum.test.simulation.sim_random import DefaultSimRandom
 N = 4
 F = 1
 
+
 # TestRunningTimeLimitSec = 600
 
 
@@ -28,19 +29,19 @@ def builder(consensus_data_provider):
 def test_calc_batches_empty(builder):
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
     vcs = [
-        ViewChange(viewNo=0, stableCheckpoint=0, prepared=[], preprepared=[], checkpoints=[cp]),
-        ViewChange(viewNo=0, stableCheckpoint=0, prepared=[], preprepared=[], checkpoints=[cp]),
-        ViewChange(viewNo=0, stableCheckpoint=0, prepared=[], preprepared=[], checkpoints=[cp]),
-        ViewChange(viewNo=0, stableCheckpoint=0, prepared=[], preprepared=[], checkpoints=[cp]),
+        ViewChange(viewNo=1, stableCheckpoint=0, prepared=[], preprepared=[], checkpoints=[cp]),
+        ViewChange(viewNo=1, stableCheckpoint=0, prepared=[], preprepared=[], checkpoints=[cp]),
+        ViewChange(viewNo=1, stableCheckpoint=0, prepared=[], preprepared=[], checkpoints=[cp]),
+        ViewChange(viewNo=1, stableCheckpoint=0, prepared=[], preprepared=[], checkpoints=[cp]),
     ]
     assert [] == builder.calc_batches(cp, vcs)
 
 
 def test_calc_batches_quorum(builder):
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
-    vc = ViewChange(viewNo=0, stableCheckpoint=0,
-                    prepared=[(0, 1, "digest1"), (0, 2, "digest2")],
-                    preprepared=[(0, 1, "digest1"), (0, 2, "digest2"), (0, 3, "digest3")],
+    vc = ViewChange(viewNo=1, stableCheckpoint=0,
+                    prepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2")],
+                    preprepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2"), (0, 0, 3, "digest3")],
                     checkpoints=[cp])
 
     vcs = [vc]
@@ -55,20 +56,72 @@ def test_calc_batches_quorum(builder):
 
 def test_calc_batches_same_data(builder):
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
-    vc = ViewChange(viewNo=0, stableCheckpoint=0,
-                    prepared=[(0, 1, "digest1"), (0, 2, "digest2")],
-                    preprepared=[(0, 1, "digest1"), (0, 2, "digest2")],
+    vc = ViewChange(viewNo=1, stableCheckpoint=0,
+                    prepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2")],
+                    preprepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2")],
                     checkpoints=[cp])
 
     vcs = [vc, vc, vc, vc]
-    assert builder.calc_batches(cp, vcs) == [BatchID(0, 1, "digest1"), BatchID(0, 2, "digest2")]
+    assert builder.calc_batches(cp, vcs) == [BatchID(0, 0, 1, "digest1"), BatchID(0, 0, 2, "digest2")]
+
+
+def test_calc_batches_same_data_prev_pp_viewno(builder):
+    cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
+    vc = ViewChange(viewNo=2, stableCheckpoint=0,
+                    prepared=[(1, 0, 1, "digest1"), (1, 0, 2, "digest2")],
+                    preprepared=[(1, 0, 1, "digest1"), (1, 0, 2, "digest2")],
+                    checkpoints=[cp])
+
+    vcs = [vc, vc, vc, vc]
+    assert builder.calc_batches(cp, vcs) == [BatchID(1, 0, 1, "digest1"), BatchID(1, 0, 2, "digest2")]
+
+
+def test_calc_batches_diff_pp_viewno(builder):
+    cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
+    vc1 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(1, 0, 1, "digest1"), (1, 0, 2, "digest2")],
+                     preprepared=[(1, 0, 1, "digest1"), (1, 0, 2, "digest2")],
+                     checkpoints=[cp])
+    vc2 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(1, 1, 1, "digest1"), (1, 1, 2, "digest2")],
+                     preprepared=[(1, 1, 1, "digest1"), (1, 1, 2, "digest2")],
+                     checkpoints=[cp])
+
+    vcs = [vc1, vc1, vc2, vc2]
+    assert builder.calc_batches(cp, vcs) is None
+
+
+def test_calc_batches_diff_pp_viewno_in_prepare_and_preprepare(builder):
+    cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
+    vc = ViewChange(viewNo=2, stableCheckpoint=0,
+                    prepared=[(1, 0, 1, "digest1"), (1, 0, 2, "digest2")],
+                    preprepared=[(1, 1, 1, "digest1"), (1, 1, 2, "digest2")],
+                    checkpoints=[cp])
+
+    vcs = [vc, vc, vc, vc]
+    assert builder.calc_batches(cp, vcs) is None
+
+
+def test_calc_batches_diff_pp_viewno_in_preprepare(builder):
+    cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
+    vc1 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(1, 0, 1, "digest1"), (1, 0, 2, "digest2")],
+                     preprepared=[(1, 0, 1, "digest1"), (1, 0, 2, "digest2")],
+                     checkpoints=[cp])
+    vc2 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(1, 0, 1, "digest1"), (1, 0, 2, "digest2")],
+                     preprepared=[(1, 1, 1, "digest1"), (1, 1, 2, "digest2")],
+                     checkpoints=[cp])
+
+    vcs = [vc1, vc2, vc2, vc2]
+    assert builder.calc_batches(cp, vcs) is None
 
 
 def test_calc_batches_must_be_in_pre_prepare(builder):
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
-    vc = ViewChange(viewNo=0, stableCheckpoint=0,
-                    prepared=[(0, 1, "digest1"), (0, 2, "digest2")],
-                    preprepared=[(0, 1, "digest1")],
+    vc = ViewChange(viewNo=1, stableCheckpoint=0,
+                    prepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2")],
+                    preprepared=[(0, 0, 1, "digest1")],
                     checkpoints=[cp])
 
     vcs = [vc, vc, vc, vc]
@@ -76,90 +129,127 @@ def test_calc_batches_must_be_in_pre_prepare(builder):
     # so, None here means we can not calculate NewView reliably
     assert builder.calc_batches(cp, vcs) is None
 
-    vc1 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1"), (0, 2, "digest2")],
-                     preprepared=[(0, 1, "digest1")],
+    cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
+    vc = ViewChange(viewNo=1, stableCheckpoint=0,
+                    prepared=[(0, 1, 1, "digest1"), (0, 1, 2, "digest2")],
+                    preprepared=[(0, 0, 1, "digest1")],
+                    checkpoints=[cp])
+
+    vcs = [vc, vc, vc, vc]
+    # all nodes are malicious here since their view_no is different from the PrePrepare ones
+    # so, None here means we can not calculate NewView reliably
+    assert builder.calc_batches(cp, vcs) is None
+
+    cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
+    vc = ViewChange(viewNo=1, stableCheckpoint=0,
+                    prepared=[(1, 1, 1, "digest1"), (1, 1, 2, "digest2")],
+                    preprepared=[(0, 1, 1, "digest1")],
+                    checkpoints=[cp])
+
+    vcs = [vc, vc, vc, vc]
+    # all nodes are malicious here since their pp_view_no is different from the PrePrepare ones
+    # so, None here means we can not calculate NewView reliably
+    assert builder.calc_batches(cp, vcs) is None
+
+    vc1 = ViewChange(viewNo=1, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2")],
+                     preprepared=[(0, 0, 1, "digest1")],
                      checkpoints=[cp])
-    vc2 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1")],
-                     preprepared=[(0, 1, "digest1")],
+    vc2 = ViewChange(viewNo=1, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest1")],
+                     preprepared=[(0, 0, 1, "digest1")],
                      checkpoints=[cp])
 
     vcs = [vc1, vc2, vc2, vc2]
-    assert builder.calc_batches(cp, vcs) == [BatchID(0, 1, "digest1")]
+    assert builder.calc_batches(cp, vcs) == [BatchID(0, 0, 1, "digest1")]
 
 
 def test_calc_batches_takes_prepared_only(builder):
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
-    vc = ViewChange(viewNo=0, stableCheckpoint=0,
+    vc = ViewChange(viewNo=1, stableCheckpoint=0,
                     prepared=[],
-                    preprepared=[(0, 1, "digest1"), (0, 2, "digest2"), (0, 3, "digest3"), (0, 4, "digest4")],
+                    preprepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2"), (0, 0, 3, "digest3"),
+                                 (0, 0, 4, "digest4")],
                     checkpoints=[cp])
 
     vcs = [vc, vc, vc, vc]
     assert builder.calc_batches(cp, vcs) == []
 
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
-    vc = ViewChange(viewNo=0, stableCheckpoint=0,
-                    prepared=[(0, 1, "digest1"), (0, 2, "digest2")],
-                    preprepared=[(0, 1, "digest1"), (0, 2, "digest2"), (0, 3, "digest3"), (0, 4, "digest4")],
+    vc = ViewChange(viewNo=1, stableCheckpoint=0,
+                    prepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2")],
+                    preprepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2"), (0, 0, 3, "digest3"),
+                                 (0, 0, 4, "digest4")],
                     checkpoints=[cp])
 
     vcs = [vc, vc, vc, vc]
-    assert builder.calc_batches(cp, vcs) == [BatchID(0, 1, "digest1"), BatchID(0, 2, "digest2")]
+    assert builder.calc_batches(cp, vcs) == [BatchID(0, 0, 1, "digest1"), BatchID(0, 0, 2, "digest2")]
 
 
-def test_calc_batches_takes_max_view(builder):
+def test_calc_batches_takes_max_view_same_pp_view(builder):
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
-    vc = ViewChange(viewNo=0, stableCheckpoint=0,
-                    prepared=[(0, 1, "digest1"), (0, 2, "digest2"), (1, 1, "digest1"), (1, 2, "digest2")],
-                    preprepared=[(0, 1, "digest1"), (0, 2, "digest2"), (1, 1, "digest1"), (1, 2, "digest2")],
+    vc = ViewChange(viewNo=2, stableCheckpoint=0,
+                    prepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2"), (1, 1, 1, "digest1"), (1, 1, 2, "digest2")],
+                    preprepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2"), (1, 1, 1, "digest1"),
+                                 (1, 1, 2, "digest2")],
                     checkpoints=[cp])
 
     vcs = [vc, vc, vc, vc]
-    assert builder.calc_batches(cp, vcs) == [BatchID(1, 1, "digest1"), BatchID(1, 2, "digest2")]
+    assert builder.calc_batches(cp, vcs) == [BatchID(1, 1, 1, "digest1"), BatchID(1, 1, 2, "digest2")]
+
+
+def test_calc_batches_takes_max_view_diff_pp_view(builder):
+    cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
+    vc = ViewChange(viewNo=2, stableCheckpoint=0,
+                    prepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2"), (1, 0, 1, "digest1"), (1, 0, 2, "digest2")],
+                    preprepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2"), (1, 0, 1, "digest1"),
+                                 (1, 0, 2, "digest2")],
+                    checkpoints=[cp])
+
+    vcs = [vc, vc, vc, vc]
+    assert builder.calc_batches(cp, vcs) == [BatchID(1, 0, 1, "digest1"), BatchID(1, 0, 2, "digest2")]
 
 
 def test_calc_batches_respects_checkpoint(builder):
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=10, digest=cp_digest(10))
-    vc = ViewChange(viewNo=0, stableCheckpoint=0,
-                    prepared=[(0, 1, "digest1"), (0, 2, "digest2")],
-                    preprepared=[(0, 1, "digest1"), (0, 2, "digest2")],
+    vc = ViewChange(viewNo=1, stableCheckpoint=0,
+                    prepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2")],
+                    preprepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2")],
                     checkpoints=[cp])
 
     vcs = [vc, vc, vc, vc]
     assert builder.calc_batches(cp, vcs) == []
 
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=10, digest=cp_digest(10))
-    vc = ViewChange(viewNo=0, stableCheckpoint=0,
-                    prepared=[(0, 10, "digest10"), (0, 11, "digest11"), (1, 12, "digest12")],
-                    preprepared=[(0, 10, "digest10"), (0, 11, "digest11"), (1, 12, "digest12")],
+    vc = ViewChange(viewNo=2, stableCheckpoint=0,
+                    prepared=[(0, 0, 10, "digest10"), (0, 0, 11, "digest11"), (1, 0, 12, "digest12")],
+                    preprepared=[(0, 0, 10, "digest10"), (0, 0, 11, "digest11"), (1, 0, 12, "digest12")],
                     checkpoints=[cp])
 
     vcs = [vc, vc, vc, vc]
-    assert builder.calc_batches(cp, vcs) == [BatchID(0, 11, "digest11"), BatchID(1, 12, "digest12")]
+    assert builder.calc_batches(cp, vcs) == [BatchID(0, 0, 11, "digest11"), BatchID(1, 0, 12, "digest12")]
 
 
 def test_calc_batches_takes_quorum_of_prepared(builder):
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
-    vc1 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest2")],
-                     preprepared=[(0, 1, "digest2")],
+    vc1 = ViewChange(viewNo=1, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest2")],
+                     preprepared=[(0, 0, 1, "digest2")],
                      checkpoints=[cp])
-    vc2 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1")],
-                     preprepared=[(0, 1, "digest1")],
+    vc2 = ViewChange(viewNo=1, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest1")],
+                     preprepared=[(0, 0, 1, "digest1")],
                      checkpoints=[cp])
-    vc3 = ViewChange(viewNo=0, stableCheckpoint=0,
+    vc3 = ViewChange(viewNo=1, stableCheckpoint=0,
                      prepared=[],
-                     preprepared=[(0, 1, "digest1")],
+                     preprepared=[(0, 0, 1, "digest1")],
                      checkpoints=[cp])
 
     vcs = [vc1, vc2, vc2, vc2]
-    assert builder.calc_batches(cp, vcs) == [BatchID(0, 1, "digest1")]
+    assert builder.calc_batches(cp, vcs) == [BatchID(0, 0, 1, "digest1")]
 
     vcs = [vc3, vc2, vc2, vc2]
-    assert builder.calc_batches(cp, vcs) == [BatchID(0, 1, "digest1")]
+    assert builder.calc_batches(cp, vcs) == [BatchID(0, 0, 1, "digest1")]
 
     vcs = [vc3, vc3, vc3, vc3]
     assert builder.calc_batches(cp, vcs) == []
@@ -169,130 +259,130 @@ def test_calc_batches_takes_quorum_of_prepared(builder):
 
     # since we have enough pre-prepares
     vcs = [vc2, vc3, vc3, vc3]
-    assert builder.calc_batches(cp, vcs) == [BatchID(0, 1, "digest1")]
+    assert builder.calc_batches(cp, vcs) == [BatchID(0, 0, 1, "digest1")]
     vcs = [vc2, vc2, vc3, vc3]
-    assert builder.calc_batches(cp, vcs) == [BatchID(0, 1, "digest1")]
+    assert builder.calc_batches(cp, vcs) == [BatchID(0, 0, 1, "digest1")]
 
 
 def test_calc_batches_takes_one_prepared_if_weak_quorum_of_preprepared(builder):
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
-    vc1 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1"), (0, 2, "digest2")],
-                     preprepared=[(0, 1, "digest1"), (0, 2, "digest2")],
+    vc1 = ViewChange(viewNo=1, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2")],
+                     preprepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2")],
                      checkpoints=[cp])
-    vc2 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1")],
-                     preprepared=[(0, 1, "digest1"), (0, 2, "digest2")],
+    vc2 = ViewChange(viewNo=1, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest1")],
+                     preprepared=[(0, 0, 1, "digest1"), (0, 0, 2, "digest2")],
                      checkpoints=[cp])
-    vc3 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1")],
-                     preprepared=[(0, 1, "digest1")],
+    vc3 = ViewChange(viewNo=1, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest1")],
+                     preprepared=[(0, 0, 1, "digest1")],
                      checkpoints=[cp])
-    vc4 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1")],
-                     preprepared=[(0, 1, "digest1")],
+    vc4 = ViewChange(viewNo=1, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest1")],
+                     preprepared=[(0, 0, 1, "digest1")],
                      checkpoints=[cp])
 
     vcs = [vc1, vc2, vc3, vc4]
-    assert builder.calc_batches(cp, vcs) == [BatchID(0, 1, "digest1"), (0, 2, "digest2")]
+    assert builder.calc_batches(cp, vcs) == [BatchID(0, 0, 1, "digest1"), (0, 0, 2, "digest2")]
 
 
 def test_calc_batches_takes_next_view_one_prepared_if_weak_quorum_of_preprepared(builder):
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
-    vc1 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1"), (1, 2, "digest2")],
-                     preprepared=[(0, 1, "digest1"), (1, 2, "digest2")],
+    vc1 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest1"), (1, 1, 2, "digest2")],
+                     preprepared=[(0, 0, 1, "digest1"), (1, 1, 2, "digest2")],
                      checkpoints=[cp])
-    vc2 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1")],
-                     preprepared=[(0, 1, "digest1"), (1, 2, "digest2")],
+    vc2 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest1")],
+                     preprepared=[(0, 0, 1, "digest1"), (1, 1, 2, "digest2")],
                      checkpoints=[cp])
-    vc3 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1")],
-                     preprepared=[(0, 1, "digest1")],
+    vc3 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest1")],
+                     preprepared=[(0, 0, 1, "digest1")],
                      checkpoints=[cp])
-    vc4 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1")],
-                     preprepared=[(0, 1, "digest1")],
+    vc4 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest1")],
+                     preprepared=[(0, 0, 1, "digest1")],
                      checkpoints=[cp])
 
     vcs = [vc1, vc2, vc3, vc4]
-    assert builder.calc_batches(cp, vcs) == [BatchID(0, 1, "digest1"), (1, 2, "digest2")]
+    assert builder.calc_batches(cp, vcs) == [BatchID(0, 0, 1, "digest1"), (1, 1, 2, "digest2")]
 
 
 def test_calc_batches_takes_next_view_prepared_if_old_view_prepared(builder):
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
-    vc1 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(1, 1, "digest2")],
-                     preprepared=[(0, 1, "digest1"), (1, 1, "digest2")],
+    vc1 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(1, 1, 1, "digest2")],
+                     preprepared=[(0, 0, 1, "digest1"), (1, 1, 1, "digest2")],
                      checkpoints=[cp])
     vc2 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1")],
-                     preprepared=[(0, 1, "digest1"), (1, 1, "digest2")],
+                     prepared=[(0, 0, 1, "digest1")],
+                     preprepared=[(0, 0, 1, "digest1"), (1, 1, 1, "digest2")],
                      checkpoints=[cp])
-    vc3 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1")],
-                     preprepared=[(0, 1, "digest1")],
+    vc3 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest1")],
+                     preprepared=[(0, 0, 1, "digest1")],
                      checkpoints=[cp])
-    vc4 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1")],
-                     preprepared=[(0, 1, "digest1")],
+    vc4 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest1")],
+                     preprepared=[(0, 0, 1, "digest1")],
                      checkpoints=[cp])
 
     vcs = [vc1, vc2, vc3, vc4]
-    assert builder.calc_batches(cp, vcs) == [BatchID(1, 1, "digest2")]
+    assert builder.calc_batches(cp, vcs) == [BatchID(1, 1, 1, "digest2")]
 
 
 def test_calc_batches_takes_prepared_if_preprepared_in_next_view(builder):
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
-    vc1 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(1, 1, "digest2")],
-                     preprepared=[(0, 1, "digest1"), (2, 1, "digest2")],
+    vc1 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(1, 0, 1, "digest2")],
+                     preprepared=[(0, 0, 1, "digest1"), (2, 0, 1, "digest2")],
                      checkpoints=[cp])
-    vc2 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1")],
-                     preprepared=[(0, 1, "digest1"), (2, 1, "digest2")],
+    vc2 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest1")],
+                     preprepared=[(0, 0, 1, "digest1"), (2, 0, 1, "digest2")],
                      checkpoints=[cp])
-    vc3 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1")],
-                     preprepared=[(0, 1, "digest1")],
+    vc3 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest1")],
+                     preprepared=[(0, 0, 1, "digest1")],
                      checkpoints=[cp])
-    vc4 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(0, 1, "digest1")],
-                     preprepared=[(0, 1, "digest1")],
+    vc4 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(0, 0, 1, "digest1")],
+                     preprepared=[(0, 0, 1, "digest1")],
                      checkpoints=[cp])
 
     vcs = [vc1, vc2, vc3, vc4]
-    assert builder.calc_batches(cp, vcs) == [BatchID(1, 1, "digest2")]
+    assert builder.calc_batches(cp, vcs) == [BatchID(1, 0, 1, "digest2")]
 
 
 def test_calc_batches_takes_prepared_with_same_batchid_only(builder):
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
-    vc1 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(1, 1, "digest1")],
-                     preprepared=[(1, 1, "digest1")],
+    vc1 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(1, 1, 1, "digest1")],
+                     preprepared=[(1, 1, 1, "digest1")],
                      checkpoints=[cp])
-    vc2 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(1, 1, "digest1")],
-                     preprepared=[(1, 1, "digest1")],
+    vc2 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(1, 1, 1, "digest1")],
+                     preprepared=[(1, 1, 1, "digest1")],
                      checkpoints=[cp])
-    vc3 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(1, 1, "digest2")],
-                     preprepared=[(1, 1, "digest2")],
+    vc3 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(1, 1, 1, "digest2")],
+                     preprepared=[(1, 1, 1, "digest2")],
                      checkpoints=[cp])
-    vc4 = ViewChange(viewNo=0, stableCheckpoint=0,
+    vc4 = ViewChange(viewNo=2, stableCheckpoint=0,
                      prepared=[],
-                     preprepared=[(1, 1, "digest1")],
+                     preprepared=[(1, 1, 1, "digest1")],
                      checkpoints=[cp])
 
     vcs = [vc1, vc2, vc3, vc4]
-    assert builder.calc_batches(cp, vcs) == [BatchID(1, 1, "digest1")]
+    assert builder.calc_batches(cp, vcs) == [BatchID(1, 1, 1, "digest1")]
 
 
 def test_calc_checkpoints_empty(builder):
-    vc = ViewChange(viewNo=0, stableCheckpoint=0,
-                    prepared=[(1, 1, "digest1")],
-                    preprepared=[(1, 1, "digest1")],
+    vc = ViewChange(viewNo=2, stableCheckpoint=0,
+                    prepared=[(1, 1, 1, "digest1")],
+                    preprepared=[(1, 1, 1, "digest1")],
                     checkpoints=[])
     vcs = [vc, vc, vc, vc]
     assert builder.calc_checkpoint(vcs) is None
@@ -300,9 +390,9 @@ def test_calc_checkpoints_empty(builder):
 
 def test_calc_checkpoints_equal_initial(builder):
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
-    vc = ViewChange(viewNo=0, stableCheckpoint=0,
-                    prepared=[(1, 1, "digest1")],
-                    preprepared=[(1, 1, "digest1")],
+    vc = ViewChange(viewNo=2, stableCheckpoint=0,
+                    prepared=[(1, 1, 1, "digest1")],
+                    preprepared=[(1, 1, 1, "digest1")],
                     checkpoints=[cp])
     vcs = [vc, vc, vc, vc]
     assert builder.calc_checkpoint(vcs) == cp
@@ -310,9 +400,9 @@ def test_calc_checkpoints_equal_initial(builder):
 
 def test_calc_checkpoints_equal_no_stable(builder):
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=10, digest=cp_digest(0))
-    vc = ViewChange(viewNo=0, stableCheckpoint=0,
-                    prepared=[(1, 1, "digest1")],
-                    preprepared=[(1, 1, "digest1")],
+    vc = ViewChange(viewNo=2, stableCheckpoint=0,
+                    prepared=[(1, 1, 1, "digest1")],
+                    preprepared=[(1, 1, 1, "digest1")],
                     checkpoints=[cp])
     vcs = [vc, vc, vc, vc]
     assert builder.calc_checkpoint(vcs) == cp
@@ -320,9 +410,9 @@ def test_calc_checkpoints_equal_no_stable(builder):
 
 def test_calc_checkpoints_equal_stable(builder):
     cp = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=10, digest=cp_digest(0))
-    vc = ViewChange(viewNo=0, stableCheckpoint=10,
-                    prepared=[(1, 1, "digest1")],
-                    preprepared=[(1, 1, "digest1")],
+    vc = ViewChange(viewNo=2, stableCheckpoint=10,
+                    prepared=[(1, 1, 1, "digest1")],
+                    preprepared=[(1, 1, 1, "digest1")],
                     checkpoints=[cp])
     vcs = [vc, vc, vc, vc]
     assert builder.calc_checkpoint(vcs) == cp
@@ -332,17 +422,17 @@ def test_calc_checkpoints_quorum(builder):
     cp1 = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
     cp2 = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=10, digest=cp_digest(10))
 
-    vc1 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(1, 1, "digest1")],
-                     preprepared=[(1, 1, "digest1")],
+    vc1 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(1, 1, 1, "digest1")],
+                     preprepared=[(1, 1, 1, "digest1")],
                      checkpoints=[cp1])
-    vc2 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(1, 1, "digest1")],
-                     preprepared=[(1, 1, "digest1")],
+    vc2 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(1, 1, 1, "digest1")],
+                     preprepared=[(1, 1, 1, "digest1")],
                      checkpoints=[cp2])
-    vc2_stable = ViewChange(viewNo=0, stableCheckpoint=10,
-                            prepared=[(1, 1, "digest1")],
-                            preprepared=[(1, 1, "digest1")],
+    vc2_stable = ViewChange(viewNo=2, stableCheckpoint=10,
+                            prepared=[(1, 1, 1, "digest1")],
+                            preprepared=[(1, 1, 1, "digest1")],
                             checkpoints=[cp2])
 
     vcs = [vc1, vc1, vc1, vc1]
@@ -387,29 +477,29 @@ def test_calc_checkpoints_selects_max(builder):
     cp2 = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=10, digest=cp_digest(10))
     cp3 = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=20, digest=cp_digest(20))
 
-    vc1 = ViewChange(viewNo=0, stableCheckpoint=0,
-                     prepared=[(1, 1, "digest1")],
-                     preprepared=[(1, 1, "digest1")],
+    vc1 = ViewChange(viewNo=2, stableCheckpoint=0,
+                     prepared=[(1, 1, 1, "digest1")],
+                     preprepared=[(1, 1, 1, "digest1")],
                      checkpoints=[cp1])
 
-    vc2_not_stable = ViewChange(viewNo=0, stableCheckpoint=0,
-                                prepared=[(1, 1, "digest1")],
-                                preprepared=[(1, 1, "digest1")],
+    vc2_not_stable = ViewChange(viewNo=2, stableCheckpoint=0,
+                                prepared=[(1, 1, 1, "digest1")],
+                                preprepared=[(1, 1, 1, "digest1")],
                                 checkpoints=[cp2])
 
-    vc2_stable = ViewChange(viewNo=0, stableCheckpoint=10,
-                            prepared=[(1, 1, "digest1")],
-                            preprepared=[(1, 1, "digest1")],
+    vc2_stable = ViewChange(viewNo=2, stableCheckpoint=10,
+                            prepared=[(1, 1, 1, "digest1")],
+                            preprepared=[(1, 1, 1, "digest1")],
                             checkpoints=[cp2])
 
-    vc3_not_stable = ViewChange(viewNo=0, stableCheckpoint=10,
-                                prepared=[(1, 1, "digest1")],
-                                preprepared=[(1, 1, "digest1")],
+    vc3_not_stable = ViewChange(viewNo=2, stableCheckpoint=10,
+                                prepared=[(1, 1, 1, "digest1")],
+                                preprepared=[(1, 1, 1, "digest1")],
                                 checkpoints=[cp3])
 
-    vc3_stable = ViewChange(viewNo=0, stableCheckpoint=10,
-                            prepared=[(1, 1, "digest1")],
-                            preprepared=[(1, 1, "digest1")],
+    vc3_stable = ViewChange(viewNo=2, stableCheckpoint=10,
+                            prepared=[(1, 1, 1, "digest1")],
+                            preprepared=[(1, 1, 1, "digest1")],
                             checkpoints=[cp3])
 
     for vc3 in (vc3_not_stable, vc3_stable):
@@ -447,17 +537,17 @@ def test_calc_checkpoints_digest(builder):
     cp2_d2 = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=10, digest=d2)
     cp2_d1 = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=10, digest=d1)
 
-    vc1_d1 = ViewChange(viewNo=0, stableCheckpoint=0,
-                        prepared=[(1, 1, "digest1")],
-                        preprepared=[(1, 1, "digest1")],
+    vc1_d1 = ViewChange(viewNo=2, stableCheckpoint=0,
+                        prepared=[(1, 1, 1, "digest1")],
+                        preprepared=[(1, 1, 1, "digest1")],
                         checkpoints=[cp1_d1])
-    vc2_d2 = ViewChange(viewNo=0, stableCheckpoint=0,
-                        prepared=[(1, 1, "digest1")],
-                        preprepared=[(1, 1, "digest1")],
+    vc2_d2 = ViewChange(viewNo=2, stableCheckpoint=0,
+                        prepared=[(1, 1, 1, "digest1")],
+                        preprepared=[(1, 1, 1, "digest1")],
                         checkpoints=[cp2_d2])
-    vc2_d1 = ViewChange(viewNo=0, stableCheckpoint=0,
-                        prepared=[(1, 1, "digest1")],
-                        preprepared=[(1, 1, "digest1")],
+    vc2_d1 = ViewChange(viewNo=2, stableCheckpoint=0,
+                        prepared=[(1, 1, 1, "digest1")],
+                        preprepared=[(1, 1, 1, "digest1")],
                         checkpoints=[cp2_d1])
 
     vcs = [vc1_d1, vc1_d1, vc2_d1, vc2_d2]
@@ -483,10 +573,10 @@ def test_calc_checkpoints_digest(builder):
 
 
 def test_calc_batches_combinations(builder, random):
-    MAX_PP_SEQ_NO = 20
-    CHEQ_FREQ = 10
-    MAX_VIEW_NO = 3
-    MAX_DIGEST_ID = 20
+    MAX_PP_SEQ_NO = 6
+    CHEQ_FREQ = 3
+    MAX_VIEW_NO = 2
+    MAX_DIGEST_ID = 6
 
     cp1 = Checkpoint(instId=0, viewNo=1, seqNoStart=0, seqNoEnd=0, digest=cp_digest(0))
     cp2 = Checkpoint(instId=0, viewNo=1, seqNoStart=0, seqNoEnd=CHEQ_FREQ, digest=cp_digest(CHEQ_FREQ))
@@ -499,8 +589,12 @@ def test_calc_batches_combinations(builder, random):
             for i in range(vc_count):
                 # PRE-PREPARED
                 num_preprepares = random.integer(0, MAX_PP_SEQ_NO)
-                pre_prepares = [(random.integer(0, MAX_VIEW_NO), i, "digest{}".format(random.integer(1, MAX_DIGEST_ID)))
-                                for i in range(1, num_preprepares + 1)]
+                pre_prepares = []
+                for i in range(1, num_preprepares + 1):
+                    view_no = random.integer(0, MAX_VIEW_NO + 1)
+                    batch_id = (view_no, random.integer(0, view_no + 1),
+                                i, "digest{}".format(random.integer(1, MAX_DIGEST_ID)))
+                    pre_prepares.append(batch_id)
 
                 # PREPARED
                 prepares_mode = random.sample(['all-preprepared', 'half-preprepared', 'random-preprepared', 'random'],
@@ -513,9 +607,12 @@ def test_calc_batches_combinations(builder, random):
                     prepares = random.sample(pre_prepares, len(pre_prepares))
                 elif prepares_mode == ['random']:
                     num_prepares = random.integer(0, MAX_PP_SEQ_NO)
-                    prepares = [
-                        (random.integer(0, MAX_VIEW_NO), i, "digest{}".format(random.integer(1, MAX_DIGEST_ID)))
-                        for i in range(1, num_prepares + 1)]
+                    prepares = []
+                    for i in range(1, num_prepares + 1):
+                        view_no = random.integer(0, MAX_VIEW_NO + 1)
+                        batch_id = (view_no, random.integer(0, view_no + 1),
+                                    i, "digest{}".format(random.integer(1, MAX_DIGEST_ID)))
+                        prepares.append(batch_id)
                 else:
                     assert False, str(prepares_mode)
 

--- a/plenum/test/consensus/view_change/test_sim_view_change.py
+++ b/plenum/test/consensus/view_change/test_sim_view_change.py
@@ -44,7 +44,7 @@ def calc_committed(view_changes):
         for vc in view_changes:
             # pp_seq_no must be present in all PrePrepares
             for pp in vc.preprepared:
-                if pp[1] == pp_seq_no:
+                if pp[2] == pp_seq_no:
                     if batch_id is None:
                         batch_id = pp
                     assert batch_id == pp

--- a/plenum/test/consensus/view_change/test_view_change_msg_creation.py
+++ b/plenum/test/consensus/view_change/test_view_change_msg_creation.py
@@ -27,11 +27,11 @@ def test_view_change_data(view_change_service, data):
     cp = Checkpoint(instId=0, viewNo=1, seqNoStart=0, seqNoEnd=10, digest=cp_digest(10))
     data.checkpoints.add(cp)
     data.stable_checkpoint = 10
-    data.prepared = [BatchID(0, 1, "digest1"),
-                     BatchID(0, 2, "digest2")]
-    data.preprepared = [BatchID(0, 1, "digest1"),
-                        BatchID(0, 2, "digest2"),
-                        BatchID(0, 3, "digest3")]
+    data.prepared = [BatchID(0, 0, 1, "digest1"),
+                     BatchID(0, 0, 2, "digest2")]
+    data.preprepared = [BatchID(0, 0, 1, "digest1"),
+                        BatchID(0, 0, 2, "digest2"),
+                        BatchID(0, 0, 3, "digest3")]
 
     view_change_service._bus.send(NeedViewChange())
 
@@ -50,11 +50,11 @@ def test_view_change_data_multiple(view_change_service, data):
     cp1 = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=10, digest=cp_digest(10))
     data.checkpoints.add(cp1)
     data.stable_checkpoint = 0
-    data.prepared = [BatchID(0, 1, "digest1"),
-                     BatchID(0, 2, "digest2")]
-    data.preprepared = [BatchID(0, 1, "digest1"),
-                        BatchID(0, 2, "digest2"),
-                        BatchID(0, 3, "digest3")]
+    data.prepared = [BatchID(0, 0, 1, "digest1"),
+                     BatchID(0, 0, 2, "digest2")]
+    data.preprepared = [BatchID(0, 0, 1, "digest1"),
+                        BatchID(0, 0, 2, "digest2"),
+                        BatchID(0, 0, 3, "digest3")]
 
     view_change_service._bus.send(NeedViewChange())
     assert data.view_no == 1
@@ -71,11 +71,11 @@ def test_view_change_data_multiple(view_change_service, data):
     cp2 = Checkpoint(instId=0, viewNo=1, seqNoStart=0, seqNoEnd=20, digest=cp_digest(20))
     data.checkpoints.add(cp2)
     data.stable_checkpoint = 0
-    data.prepared = [BatchID(1, 11, "digest11"),
-                     BatchID(1, 12, "digest12")]
-    data.preprepared = [BatchID(1, 11, "digest11"),
-                        BatchID(1, 12, "digest12"),
-                        BatchID(1, 13, "digest13")]
+    data.prepared = [BatchID(1, 1, 11, "digest11"),
+                     BatchID(1, 1, 12, "digest12")]
+    data.preprepared = [BatchID(1, 1, 11, "digest11"),
+                        BatchID(1, 1, 12, "digest12"),
+                        BatchID(1, 1, 13, "digest13")]
 
     view_change_service._bus.send(NeedViewChange())
     assert data.view_no == 2
@@ -96,11 +96,11 @@ def test_view_change_data_multiple_respects_checkpoint(view_change_service, data
     cp1 = Checkpoint(instId=0, viewNo=0, seqNoStart=0, seqNoEnd=10, digest=cp_digest(10))
     data.checkpoints.add(cp1)
     data.stable_checkpoint = 0
-    data.prepared = [BatchID(0, 1, "digest1"),
-                     BatchID(0, 2, "digest2")]
-    data.preprepared = [BatchID(0, 1, "digest1"),
-                        BatchID(0, 2, "digest2"),
-                        BatchID(0, 3, "digest3")]
+    data.prepared = [BatchID(0, 0, 1, "digest1"),
+                     BatchID(0, 0, 2, "digest2")]
+    data.preprepared = [BatchID(0, 0, 1, "digest1"),
+                        BatchID(0, 0, 2, "digest2"),
+                        BatchID(0, 0, 3, "digest3")]
 
     view_change_service._bus.send(NeedViewChange())
     assert data.view_no == 1
@@ -117,11 +117,11 @@ def test_view_change_data_multiple_respects_checkpoint(view_change_service, data
     cp2 = Checkpoint(instId=0, viewNo=1, seqNoStart=0, seqNoEnd=20, digest=cp_digest(20))
     data.checkpoints.add(cp2)
     data.stable_checkpoint = 10
-    data.prepared = [BatchID(1, 11, "digest11"),
-                     BatchID(1, 12, "digest12")]
-    data.preprepared = [BatchID(1, 11, "digest11"),
-                        BatchID(1, 12, "digest12"),
-                        BatchID(1, 13, "digest13")]
+    data.prepared = [BatchID(1, 1, 11, "digest11"),
+                     BatchID(1, 1, 12, "digest12")]
+    data.preprepared = [BatchID(1, 1, 11, "digest11"),
+                        BatchID(1, 1, 12, "digest12"),
+                        BatchID(1, 1, 13, "digest13")]
 
     view_change_service._bus.send(NeedViewChange())
     assert data.view_no == 2
@@ -147,8 +147,8 @@ def test_view_change_empty_prepares(view_change_service, data):
 
 def test_view_change_replaces_prepare(view_change_service, data):
     data.view_no = 0
-    data.prepared = [BatchID(0, 1, "digest1"),
-                     BatchID(0, 2, "digest2")]
+    data.prepared = [BatchID(0, 0, 1, "digest1"),
+                     BatchID(0, 0, 2, "digest2")]
 
     # view no 0->1
     view_change_service._bus.send(NeedViewChange())
@@ -160,8 +160,8 @@ def test_view_change_replaces_prepare(view_change_service, data):
 
     # view no 1->2
     # replace by different viewNo and digest
-    data.prepared = [BatchID(1, 1, "digest11"),
-                     BatchID(1, 2, "digest22")]
+    data.prepared = [BatchID(1, 1, 1, "digest11"),
+                     BatchID(1, 1, 2, "digest22")]
     view_change_service._bus.send(NeedViewChange())
     assert data.view_no == 2
 
@@ -171,8 +171,8 @@ def test_view_change_replaces_prepare(view_change_service, data):
 
     # view no 2->3
     # replace by different viewNo only
-    data.prepared = [BatchID(2, 2, "digest22"),
-                     BatchID(2, 3, "digest3")]
+    data.prepared = [BatchID(2, 2, 2, "digest22"),
+                     BatchID(2, 2, 3, "digest3")]
     view_change_service._bus.send(NeedViewChange())
     assert data.view_no == 3
 
@@ -183,8 +183,8 @@ def test_view_change_replaces_prepare(view_change_service, data):
 
 def test_view_change_keeps_preprepare(view_change_service, data):
     data.view_no = 0
-    data.preprepared = [BatchID(0, 1, "digest1"),
-                        BatchID(0, 2, "digest2")]
+    data.preprepared = [BatchID(0, 0, 1, "digest1"),
+                        BatchID(0, 0, 2, "digest2")]
 
     # view no 0->1
     view_change_service._bus.send(NeedViewChange())
@@ -197,30 +197,30 @@ def test_view_change_keeps_preprepare(view_change_service, data):
 
     # view no 1->2
     # do not replace since different viewNo and digest
-    data.preprepared = [BatchID(1, 1, "digest11"),
-                        BatchID(1, 2, "digest22")]
+    data.preprepared = [BatchID(1, 1, 1, "digest11"),
+                        BatchID(1, 1, 2, "digest22")]
     view_change_service._bus.send(NeedViewChange())
 
     assert data.view_no == 2
 
     msg = get_view_change(view_change_service)
     assert msg.viewNo == 2
-    assert msg.preprepared == [(0, 1, "digest1"), (0, 2, "digest2"),
-                               (1, 1, "digest11"), (1, 2, "digest22")]
+    assert msg.preprepared == [(0, 0, 1, "digest1"), (0, 0, 2, "digest2"),
+                               (1, 1, 1, "digest11"), (1, 1, 2, "digest22")]
 
     # view no 2->3
     #  replace by different viewNo only
-    data.preprepared = [BatchID(2, 2, "digest22"),
-                        BatchID(2, 3, "digest3")]
+    data.preprepared = [BatchID(2, 2, 2, "digest22"),
+                        BatchID(2, 2, 3, "digest3")]
     view_change_service._bus.send(NeedViewChange())
 
     assert data.view_no == 3
 
     msg = get_view_change(view_change_service)
     assert msg.viewNo == 3
-    assert msg.preprepared == [(0, 1, "digest1"), (0, 2, "digest2"),
-                               (1, 1, "digest11"),
-                               (2, 2, "digest22"), (2, 3, "digest3")]
+    assert msg.preprepared == [(0, 0, 1, "digest1"), (0, 0, 2, "digest2"),
+                               (1, 1, 1, "digest11"),
+                               (2, 2, 2, "digest22"), (2, 2, 3, "digest3")]
 
 
 def test_different_view_change_messages_have_different_digests(random):

--- a/plenum/test/input_validation/fields_validation/test_batch_id_field.py
+++ b/plenum/test/input_validation/fields_validation/test_batch_id_field.py
@@ -4,21 +4,26 @@ validator = BatchIDField()
 
 
 def test_valid():
-    assert not validator.validate((1, 1, "digest"))
-    assert not validator.validate((0, 1, "digest"))
-    assert not validator.validate((100, 0, "d"))
+    assert not validator.validate((0, 1, 1, "digest"))
+    assert not validator.validate((10, 10, 1, "digest"))
+    assert not validator.validate((100, 90, 0, "d"))
 
 
 def test_invalid_view_no():
-    assert validator.validate((-1, 1, "digest"))
-    assert validator.validate(("aaa", 1, "digest"))
+    assert validator.validate((-1, 1, 1, "digest"))
+    assert validator.validate(("aaa", 1, 1, "digest"))
+
+
+def test_invalid_pp_view_no():
+    assert validator.validate((1, -1, 1, "digest"))
+    assert validator.validate((1, "aaa", 1, "digest"))
 
 
 def test_invalid_pp_seq_no():
-    assert validator.validate((1, -1, "digest"))
-    assert validator.validate((1, "aaa", "digest"))
+    assert validator.validate((1, 1, -1, "digest"))
+    assert validator.validate((1, 1, "aaa", "digest"))
 
 
 def test_invalid_digest():
-    assert validator.validate((1, 1, ""))
-    assert validator.validate((1, 1, 1))
+    assert validator.validate((1, 1, 1, ""))
+    assert validator.validate((1, 1, 1, 1))

--- a/plenum/test/view_change/test_re_order_pre_prepares.py
+++ b/plenum/test/view_change/test_re_order_pre_prepares.py
@@ -44,7 +44,7 @@ def test_re_order_pre_prepares(looper, txnPoolNodeSet,
     assert lagging_node.master_last_ordered_3PC == (0, 0)
     new_master = txnPoolNodeSet[1]
     batches = [preprepare_to_batch_id(pp.viewNo, pp) for _, pp in new_master.master_replica._ordering_service.old_view_preprepares.items()]
-    new_view_msg = NewViewCheckpointsApplied(view_no=1,
+    new_view_msg = NewViewCheckpointsApplied(view_no=0,
                                              view_changes=[],
                                              checkpoint=None,
                                              batches=batches)

--- a/plenum/test/view_change/test_re_order_pre_prepares.py
+++ b/plenum/test/view_change/test_re_order_pre_prepares.py
@@ -43,8 +43,8 @@ def test_re_order_pre_prepares(looper, txnPoolNodeSet,
     # 3. Simulate View Change finish to re-order the same PrePrepare
     assert lagging_node.master_last_ordered_3PC == (0, 0)
     new_master = txnPoolNodeSet[1]
-    batches = [preprepare_to_batch_id(pp) for _, pp in new_master.master_replica._ordering_service.old_view_preprepares.items()]
-    new_view_msg = NewViewCheckpointsApplied(view_no=0,
+    batches = [preprepare_to_batch_id(pp.viewNo, pp) for _, pp in new_master.master_replica._ordering_service.old_view_preprepares.items()]
+    new_view_msg = NewViewCheckpointsApplied(view_no=1,
                                              view_changes=[],
                                              checkpoint=None,
                                              batches=batches)


### PR DESCRIPTION
- Added `pp_view_no` to every BatchID
- This is the viewNo where the PrePrepare associated with the BatchID has been applied first time (so persisted in the audit ledger)
- added new tests and fixed existing ones