### PR TITLE
INDY-2261: add ROUTER_HANDOVER option

### DIFF
--- a/stp_core/config.py
+++ b/stp_core/config.py
@@ -42,6 +42,7 @@ KEEPALIVE_INTVL = 1  # seconds
 KEEPALIVE_IDLE = 20  # seconds
 KEEPALIVE_CNT = 10
 MAX_SOCKETS = 16384 if sys.platform != 'win32' else None
+ROUTER_HANDOVER = 1
 ENABLE_HEARTBEATS = False
 HEARTBEAT_FREQ = 5  # seconds
 ZMQ_CLIENT_QUEUE_SIZE = 100  # messages (0 - no limit)

--- a/stp_zmq/zstack.py
+++ b/stp_zmq/zstack.py
@@ -367,6 +367,7 @@ class ZStack(NetworkInterface):
         self.listener = self.ctx.socket(zmq.ROUTER)
         self._client_message_provider.listener = self.listener
         self.listener.setsockopt(zmq.ROUTER_MANDATORY, 1)
+        self.listener.setsockopt(zmq.ROUTER_HANDOVER, self.config.ROUTER_HANDOVER)
         if self.create_listener_monitor:
             self.listener_monitor = self.listener.get_monitor_socket()
         # noinspection PyUnresolvedReferences


### PR DESCRIPTION
A try to deal with reconnections by always using the latest connection with the same ID (all our Nodes use the same ID equal to the pubkey).