### PR TITLE
Add validations for TAA_ACCEPTANCE_TIME and timestamps in the TAA txn

### DIFF
--- a/plenum/server/client_error_codes.py
+++ b/plenum/server/client_error_codes.py
@@ -15,6 +15,7 @@ class Rejects:
                                             "Txn Author Agreement acceptance time is inappropriate: provided {}, expected in [{}, {}]")
     TAA_AML_INVALID = ClientError(206,
                                   "Txn Author Agreement acceptance mechanism is inappropriate: provided {}, expected one of {}")
+    TAA_INCORRECT_ACCEPTANCE_TIME_FORMAT = ClientError(207, "TAA_ACCEPTANCE_TIME = {} is out of range")
 
 
 class Nacks:

--- a/plenum/server/request_managers/write_request_manager.py
+++ b/plenum/server/request_managers/write_request_manager.py
@@ -347,7 +347,13 @@ class WriteRequestManager(RequestManager):
             )
 
         r_taa_a_ts = request.taaAcceptance[f.TAA_ACCEPTANCE_TIME.nm]
-        datetime_r_taa = datetime.utcfromtimestamp(r_taa_a_ts)
+        try:
+            datetime_r_taa = datetime.utcfromtimestamp(r_taa_a_ts)
+        except ValueError:
+            raise InvalidClientTaaAcceptanceError(
+                request.identifier, request.reqId,
+                Rejects.TAA_INCORRECT_ACCEPTANCE_TIME_FORMAT.reason.format(r_taa_a_ts),
+                Rejects.TAA_INCORRECT_ACCEPTANCE_TIME_FORMAT.code)
         if datetime_r_taa.time() != time(0):
             raise InvalidClientTaaAcceptanceError(
                 request.identifier, request.reqId,

--- a/plenum/test/txn_author_agreement/acceptance/test_taa_acceptance_validation.py
+++ b/plenum/test/txn_author_agreement/acceptance/test_taa_acceptance_validation.py
@@ -106,6 +106,21 @@ def test_taa_acceptance_mechanism_inappropriate(
         validate_taa_acceptance(request_dict)
 
 
+def test_taa_acceptance_with_incorrect_time(
+    validate_taa_acceptance, validation_error,
+    request_dict
+):
+    request_dict[f.TAA_ACCEPTANCE.nm][f.TAA_ACCEPTANCE_TIME.nm] *= 1000
+    with pytest.raises(
+        validation_error,
+        match=(
+            r"TAA_ACCEPTANCE_TIME = {} is "
+            r"out of range.".format(request_dict[f.TAA_ACCEPTANCE.nm][f.TAA_ACCEPTANCE_TIME.nm])
+        )
+    ):
+        validate_taa_acceptance(request_dict)
+
+
 def test_taa_acceptance_time_near_lower_threshold(
     tconf, txnPoolNodeSet, validate_taa_acceptance, validation_error,
     turn_off_freshness_state_update, max_last_accepted_pre_prepare_time,

--- a/plenum/test/txn_author_agreement/test_txn_author_agreement.py
+++ b/plenum/test/txn_author_agreement/test_txn_author_agreement.py
@@ -97,6 +97,29 @@ def test_create_txn_author_agreement_with_ratified_from_future_fails(looper, set
                                       ratified=get_utc_epoch() + 600)
 
 
+def test_create_txn_author_agreement_with_milliseconds_ratified_fails(looper, set_txn_author_agreement_aml,
+                                                                     sdk_pool_handle, sdk_wallet_trustee):
+    ratified = get_utc_epoch() * 1000
+    with pytest.raises(RequestNackedException,
+                       match="{} = {} is out of range.".format(TXN_AUTHOR_AGREEMENT_RATIFICATION_TS, ratified)):
+        sdk_send_txn_author_agreement(looper, sdk_pool_handle, sdk_wallet_trustee,
+                                      version=randomString(16),
+                                      text=randomString(1024),
+                                      ratified=ratified)
+
+
+def test_create_txn_author_agreement_with_milliseconds_retired_fails(looper, set_txn_author_agreement_aml,
+                                                                     sdk_pool_handle, sdk_wallet_trustee):
+    retired = get_utc_epoch() * 1000
+    with pytest.raises(RequestNackedException,
+                       match="{} = {} is out of range.".format(TXN_AUTHOR_AGREEMENT_RETIREMENT_TS, retired)):
+        sdk_send_txn_author_agreement(looper, sdk_pool_handle, sdk_wallet_trustee,
+                                      version=randomString(16),
+                                      text=randomString(1024),
+                                      ratified=get_utc_epoch() - 600,
+                                      retired=retired)
+
+
 @pytest.mark.parametrize('retired_offset', [-600, 600])
 def test_create_txn_author_agreement_with_retired_date_fails(looper, set_txn_author_agreement_aml,
                                                              sdk_pool_handle, sdk_wallet_trustee,


### PR DESCRIPTION
'datetime.utcfromtimestamp'  throws ValueError exception if a timestamp in milliseconds.