### PR TITLE
adds support for github actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,41 @@
+name: indy-plenum-build
+on: [ push, pull_request ]
+
+jobs:
+  indy_plenum:
+    name: Build Indy Plenum
+    runs-on: ubuntu-18.04
+    #TODO: move this to hyperledger?
+    container: m00sey/indy-node-build:latest
+    strategy:
+      matrix:
+        module: [common, crypto, ledger, plenum, state, storage, stp_core, stp_zmq]
+      fail-fast: false
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: pip install .[tests]
+
+      - name: Run Indy Plenum ${{ matrix.module }} tests
+        run: python -m pytest -l -vv --junitxml=test-result-plenum-${{ matrix.module }}.xml ${{ matrix.module }}
+
+      - name: Publish Test Report
+        uses: scacap/action-surefire-report@v1
+        with:
+          check_name: Indy Plenum ${{ matrix.module }} Test Report
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: test-result-plenum-${{ matrix.module }}.xml
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-18.04
+    #TODO: move this to hyperledger?
+    container: m00sey/indy-node-lint:latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: flake8
+        run: python3 -m flake8

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ var/
 *.egg
 *.eggs
 
+# Needed for GitHub Actions
+!.github/workflows/build
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
@@ -86,8 +89,9 @@ venv/
 # generated doc files
 docs/source/api_docs/
 
-# hidden files
-.*
+# IntelliJ specific config
+*.idea
+*.iml
 
 # log files
 *.log
@@ -101,7 +105,5 @@ target/
 # Ipython Notebook
 .ipynb_checkpoints
 
-# Hidden files
-.*
 
 


### PR DESCRIPTION
a port of the current Jenkins ci file as suggested by @Toktar over on indy node (https://github.com/hyperledger/indy-node/pull/1622#issuecomment-724694524)

Currently, the plenum tests fail in this format. (help required)

Signed-off-by: m00sey <griffin.kev@gmail.com>