### PR TITLE
Fixing CD pipeline

### DIFF
--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -265,7 +265,7 @@ options.setBuiltPkgs([
     'python3-rocksdb': '0.6.9',
     'python3-pympler': '0.8',
     'python3-packaging': '19.0',
-    'python3-ursa': '0.1.0'
+    'python3-ursa': '0.1.1'
 ])
 
 

--- a/build-scripts/ubuntu-1604/build-3rd-parties.sh
+++ b/build-scripts/ubuntu-1604/build-3rd-parties.sh
@@ -104,4 +104,4 @@ build_from_pypi jsonpickle 0.9.6
 build_from_pypi python-rocksdb 0.6.9
 build_from_pypi pympler 0.8
 build_from_pypi packaging 19.0
-build_from_pypi python-ursa 0.1.0
+build_from_pypi python-ursa 0.1.1

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(
                         'python-dateutil==2.6.1',
                         'pympler==0.8',
                         'packaging==19.0',
-                        'python-ursa==0.1.0',
+                        'python-ursa==0.1.1',
                       ],
 
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
Bumped version of python-ursa to 0.1.1. This version includes sources distribution that is required by pipelines.