### PR TITLE
Split CD release into two parts, added caching, and extended Docker file

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -186,31 +186,58 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v1
 
-      - name: Install os dependencies
-        run: ./build-scripts/ubuntu-1604/install-os-dependencies.sh
-
-      - name: Install os tools
-        run: ./build-scripts/ubuntu-1604/install-os-tools.sh
-
       - name: Build Indy Plenum deployment package
-        run: ./build-scripts/ubuntu-1604/build-indy-plenum.sh /__w/indy-plenum/indy-plenum 1.14.0 /tmp
+        run: |
+          mkdir -p /tmp/build-output
+          ./build-scripts/ubuntu-1604/build-indy-plenum.sh /__w/indy-plenum/indy-plenum 1.14.0 /tmp/build-output
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: plenum-deb
+          path: /tmp/build-output
+
+  build_plenum_3rd_party_dependencies:
+    name: Indy Plenum 3rd Party Dependencies
+    needs: [workflow-setup, indy_plenum, indy_plenum_tests, lint]
+    runs-on: ubuntu-20.04
+    container:
+      image: ghcr.io/${{ needs.workflow-setup.outputs.GITHUB_REPOSITORY_NAME }}/plenum-build
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Try load from cache.
+        id: third-party-dependencies
+        uses: actions/cache@v2
+        with:
+          path: /tmp/cache
+          key: ${{ hashFiles('./build-scripts/ubuntu-1604/build-3rd-parties.sh') }}
 
       - name: Build 3rd party deployment packages
-        run: ./build-scripts/ubuntu-1604/build-3rd-parties.sh
+        if: steps.third-party-dependencies.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ./build-scripts/ubuntu-1604/cache/3rd-party-dependencies/  
+          ./build-scripts/ubuntu-1604/build-3rd-parties.sh ./cache/3rd-party-dependencies/
+          cd ./build-scripts/ubuntu-1604
+          mv ./cache/* /tmp/cache
+      
 
   publish_plenum_rc:
     name: Publish release candidate
     runs-on: ubuntu-20.04
-    needs: ['build_plenum_release']
+    needs: ['build_plenum_release', 'build_plenum_3rd_party_dependencies']
     if: github.event_name == 'push' && (github.repository == 'hyperledger/indy-plenum' && github.ref == 'refs/heads/release*')
     steps:
       - name: pub
         run: |
           echo "publish rc"
+
   publish_plenum_release:
     name: Publish release
     runs-on: ubuntu-20.04
-    needs: ['build_plenum_release']
+    needs: ['build_plenum_release', 'build_plenum_3rd_party_dependencies']
     if: github.event_name == 'push' && (github.repository == 'hyperledger/indy-plenum' && github.ref == 'refs/heads/master')
     steps:
       - name: pub

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -219,7 +219,7 @@ jobs:
         if: steps.third-party-dependencies.outputs.cache-hit != 'true'
         run: |
           mkdir -p ./build-scripts/ubuntu-1604/cache/3rd-party-dependencies/  
-          ./build-scripts/ubuntu-1604/build-3rd-parties.sh ./cache/3rd-party-dependencies/
+          ./build-scripts/ubuntu-1604/build-3rd-parties.sh ./cache/3rd-party-dependencies
           cd ./build-scripts/ubuntu-1604
           mv ./cache/* /tmp/cache
       

--- a/.github/workflows/build/Dockerfile
+++ b/.github/workflows/build/Dockerfile
@@ -11,6 +11,15 @@ RUN apt-get update -y && apt-get install -y \
     liblz4-dev \
     libsnappy-dev \
     rocksdb=5.8.8 \
-    ursa=0.3.2-2
+    ursa=0.3.2-2 \
+# Build dependencies
+    ruby \
+    ruby-dev \
+    rubygems \
+    gcc \
+    make 
+
+# install fpm
+RUN gem install --no-ri --no-rdoc rake fpm
 
 RUN indy_image_clean

--- a/build-scripts/ubuntu-1604/build-3rd-parties.sh
+++ b/build-scripts/ubuntu-1604/build-3rd-parties.sh
@@ -15,10 +15,10 @@ function build_rocksdb_deb {
     sed -i 's/-m rocksdb@fb.com/-m "Hyperledger <hyperledger-indy@lists.hyperledger.org>"/g' \
         ./build_tools/make_package.sh
     PORTABLE=1 EXTRA_CFLAGS="-fPIC" EXTRA_CXXFLAGS="-fPIC" ./build_tools/make_package.sh $VERSION
-    cp ./package/rocksdb_${VERSION}_amd64.deb $OUTPUT_PATH
     # Install it in the system as it is needed by python-rocksdb.
     make install
     cd -
+    cp /tmp/rocksdb/package/rocksdb_${VERSION}_amd64.deb $OUTPUT_PATH
     rm -rf /tmp/rocksdb
 }
 


### PR DESCRIPTION
- Extended the Dockfile with the CD dependencies. It's not necessary anymore to install dependencies and fpm in build_plenum_release job

- split the build_plenum_release job into two jobs
- (1) build plenum release and upload deb file as an artifact
- (2) build all 3rd party dependencies and cache them. Only trigger a new build if the dependencies change