### PR TITLE
Ubuntu 20.04: remove pip imports in favor if importlib_metadata

### DIFF
--- a/.github/workflows/build/Dockerfile.ubuntu-20-04
+++ b/.github/workflows/build/Dockerfile.ubuntu-20-04
@@ -49,7 +49,6 @@ RUN pip3 install -U \
     msgpack-python==0.5.6 \
     orderedset==2.0.3 \
     packaging==20.9 \
-    pip==9.0.3 \
     pluggy==0.13.1 \
     portalocker==2.2.1 \
     prompt-toolkit==3.0.18 \

--- a/.github/workflows/lint/Dockerfile.ubuntu-16-04
+++ b/.github/workflows/lint/Dockerfile.ubuntu-16-04
@@ -14,7 +14,7 @@ RUN apt-get install -y \
 	python3-nacl
 
 RUN pip3 install -U \
-	'pip<10.0.0' \
+	pip \
 	setuptools \
 	pep8==1.7.1 \
 	pep8-naming==0.6.1 \

--- a/.github/workflows/lint/Dockerfile.ubuntu-20-04
+++ b/.github/workflows/lint/Dockerfile.ubuntu-20-04
@@ -12,7 +12,7 @@ RUN apt-get install -y \
 	python3-nacl
 
 RUN pip3 install -U \
-	'pip<10.0.0' \
+	pip \
 	setuptools==50.3.2 \
 	pep8==1.7.1 \
 	pep8-naming==0.6.1 \

--- a/plenum/__init__.py
+++ b/plenum/__init__.py
@@ -22,9 +22,9 @@ PLUGIN_CLIENT_REQUEST_FIELDS = {}
 
 def setup_plugins():
     import os   # noqa
-    import pip  # noqa
     import importlib    # noqa
     from importlib.util import module_from_spec, spec_from_file_location    # noqa: E402
+    import importlib_metadata
     import plenum   # noqa: E402
     import plenum.server.plugin     # noqa: E402
     from plenum.common.config_util import getConfigOnce   # noqa: E402
@@ -57,7 +57,7 @@ def setup_plugins():
                           format(plugin_root))
     sys.path.insert(0, plugin_root.__path__[0])
     enabled_plugins = config.ENABLED_PLUGINS
-    installed_packages = {p.project_name: p for p in pip.get_installed_distributions()}
+    installed_packages = set(p.metadata["Name"] for p in importlib_metadata.distributions())
     for plugin_name in enabled_plugins:
         plugin = find_and_load_plugin(plugin_name, plugin_root, installed_packages)
         plugin_globals = plugin.__dict__

--- a/plenum/server/notifier_plugin_manager.py
+++ b/plenum/server/notifier_plugin_manager.py
@@ -1,5 +1,5 @@
-import pip
 import importlib
+import importlib_metadata
 import math
 from typing import Dict
 import time
@@ -146,6 +146,6 @@ class PluginManager:
         return i, len(self.plugins)
 
     def _findPlugins(self):
-        return [pkg.key
-                for pkg in pip.utils.get_installed_distributions()
-                if pkg.key.startswith(PluginManager.prefix)]
+        return [pkg.metadata["Name"]
+                for pkg in importlib_metadata.distributions()
+                if pkg.metadata["Name"].startswith(PluginManager.prefix)]

--- a/plenum/server/validator_info_tool.py
+++ b/plenum/server/validator_info_tool.py
@@ -2,7 +2,6 @@ import json
 import time
 import psutil
 import platform
-import pip
 import os
 import base58
 import subprocess
@@ -10,6 +9,7 @@ import locale
 import codecs
 from dateutil import parser
 import datetime
+import importlib_metadata
 
 from crypto.bls.indy_crypto.bls_crypto_indy_crypto import IndyCryptoBlsUtils
 from ledger.genesis_txn.genesis_txn_file_util import genesis_txn_path
@@ -272,7 +272,10 @@ class ValidatorNodeInfoTool:
     @none_on_fail
     def _generate_software_info(self):
         os_version = self._prepare_for_json(platform.platform())
-        installed_packages = [self._prepare_for_json(pack) for pack in pip.get_installed_distributions()]
+        installed_packages = [
+            "{} {}".format(p.metadata["Name"], p.version)
+            for p in importlib_metadata.distributions()
+        ]
         output = self._run_external_cmd("dpkg-query --list | grep indy")
         indy_packages = output.split(os.linesep)
         return {

--- a/plenum/test/conftest.py
+++ b/plenum/test/conftest.py
@@ -24,8 +24,8 @@ from plenum.common.signer_did import DidSigner
 from plenum.common.signer_simple import SimpleSigner
 from plenum.test import waits
 
+import importlib_metadata
 import gc
-import pip
 import pytest
 import plenum.config as plenum_config
 import plenum.server.general_config.ubuntu_platform_config as platform_config
@@ -56,7 +56,7 @@ from plenum.common.util import getNoInstances, randomString
 from plenum.server.notifier_plugin_manager import PluginManager
 from plenum.test.helper import checkLastClientReqForNode, \
     waitForViewChange, requestReturnedToNode, randomText, \
-    mockGetInstalledDistributions, mockImportModule, chk_all_funcs, \
+    mockDistributions, mockImportModule, chk_all_funcs, \
     create_new_test_node, sdk_json_to_request_object, sdk_send_random_requests, \
     sdk_get_and_check_replies, sdk_set_protocol_version, sdk_send_random_and_check, MockTimer, create_pool_txn_data
 from plenum.test.node_request.node_request_helper import checkPrePrepared, \
@@ -769,8 +769,8 @@ def pluginManager(monkeypatch):
     packagesCnt = 3
     packages = [pluginManager.prefix + randomText(10)
                 for _ in range(packagesCnt)]
-    monkeypatch.setattr(pip.utils, 'get_installed_distributions',
-                        partial(mockGetInstalledDistributions,
+    monkeypatch.setattr(importlib_metadata, 'distributions',
+                        partial(mockDistributions,
                                 packages=packages))
     imported, found = pluginManager.importPlugins()
     assert imported == 3
@@ -790,8 +790,8 @@ def patchPluginManager():
 
 @pytest.fixture
 def pluginManagerWithImportedModules(pluginManager, monkeypatch):
-    monkeypatch.setattr(pip.utils, 'get_installed_distributions',
-                        partial(mockGetInstalledDistributions,
+    monkeypatch.setattr(importlib_metadata, 'distributions',
+                        partial(mockDistributions,
                                 packages=[]))
     monkeypatch.setattr(importlib, 'import_module', mockImportModule)
     imported, found = pluginManager.importPlugins()
@@ -799,8 +799,8 @@ def pluginManagerWithImportedModules(pluginManager, monkeypatch):
     packagesCnt = 3
     packages = [pluginManager.prefix + randomText(10)
                 for _ in range(packagesCnt)]
-    monkeypatch.setattr(pip.utils, 'get_installed_distributions',
-                        partial(mockGetInstalledDistributions,
+    monkeypatch.setattr(importlib_metadata, 'distributions',
+                        partial(mockDistributions,
                                 packages=packages))
     imported, found = pluginManager.importPlugins()
     assert imported == 3

--- a/plenum/test/helper.py
+++ b/plenum/test/helper.py
@@ -557,11 +557,11 @@ def randomText(size):
     return ''.join(random.choice(string.ascii_letters) for _ in range(size))
 
 
-def mockGetInstalledDistributions(packages):
+def mockDistributions(packages):
     ret = []
     for pkg in packages:
         obj = type('', (), {})()
-        obj.key = pkg
+        obj.metadata = {'Name': pkg, 'Version': 0.0}
         ret.append(obj)
     return ret
 

--- a/plenum/test/plugin/test_notifier_plugin_manager.py
+++ b/plenum/test/plugin/test_notifier_plugin_manager.py
@@ -1,7 +1,7 @@
-import pip.utils as utils
+import importlib_metadata
 import pytest
 
-from plenum.test.helper import randomText, mockGetInstalledDistributions, \
+from plenum.test.helper import randomText, mockDistributions, \
     mockImportModule
 from functools import partial
 import importlib
@@ -17,10 +17,10 @@ def testPluginManagerFindsPlugins(monkeypatch, pluginManager):
     invalidPackages = [randomText(10) for _ in range(invalidPackagesCnt)]
 
     monkeypatch.setattr(
-        utils,
-        'get_installed_distributions',
+        importlib_metadata,
+        'distributions',
         partial(
-            mockGetInstalledDistributions,
+            mockDistributions,
             packages=validPackages +
                      invalidPackages))
     assert len(pluginManager._findPlugins()) == validPackagesCnt
@@ -31,8 +31,8 @@ def testPluginManagerImportsPlugins(monkeypatch, pluginManager):
     packages = [pluginManager.prefix + randomText(10)
                 for _ in range(packagesCnt)]
 
-    monkeypatch.setattr(utils, 'get_installed_distributions',
-                        partial(mockGetInstalledDistributions,
+    monkeypatch.setattr(importlib_metadata, 'distributions',
+                        partial(mockDistributions,
                                 packages=packages))
     monkeypatch.setattr(importlib, 'import_module', mockImportModule)
 

--- a/scripts/test_zmq/common/Dockerfile
+++ b/scripts/test_zmq/common/Dockerfile
@@ -8,6 +8,6 @@ RUN apt update && apt install -y \
 
 # pypi based packages
 RUN pip3 install -U \
-    'pip<10.0.0' \
+    pip \
     setuptools \
     virtualenv

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
                         'orderedset',
                         'sortedcontainers>=1.5.7',
                         'psutil>=5.6.6',
-                        'pip<10.0.0',
+                        'importlib_metadata>=2.0',
                         'portalocker>=2.2.1',
                         # Pinned because of changing size of `crypto_sign_SECRETKEYBYTES` from 32 to 64
                         'libnacl==1.6.1',


### PR DESCRIPTION
This PR solves issue #1549. The PR just applies the adjustments made by @andrewwhitehead in this [commit](https://github.com/hyperledger/indy-plenum/pull/1548/commits/4cd59f88cddf9c13f1f73e2b1bf91cd48504d29a) to the `ubuntu-20.04-upgrade` feature branch. Thanks to @andrewwhitehead for his contribution.