### PR TITLE
Ubuntu 20.04: Publishing of Python packages to PyPI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -391,10 +391,50 @@ jobs:
           ./build-scripts/${{ needs.workflow-setup.outputs.UBUNTU_VERSION }}/build-3rd-parties.sh ./cache/3rd-party-dependencies
           mv ./build-scripts/${{ needs.workflow-setup.outputs.UBUNTU_VERSION }}/cache/* /tmp/third-party-dependencies
 
+  build-python-packages:
+    name: Build Python Packages
+    runs-on: ubuntu-20.04
+    needs: [workflow-setup, indy_plenum_tests, indy_plenum_module_tests, lint]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install required packages via pip
+        run: |
+          python3 -m pip install pytest-runner wheel
+
+      - name: Set Build Version
+        id: version
+        uses: ./.github/actions/set-version
+        with:
+          moduleName: plenum
+          isDev: ${{ needs.workflow-setup.outputs.isDev }}
+          isRC: ${{ needs.workflow-setup.outputs.isRC }}
+
+      - name: Prepare package and set version
+        run: |
+          ./build-scripts/${{ needs.workflow-setup.outputs.UBUNTU_VERSION }}/prepare-package.sh . plenum "${{ steps.version.outputs.upstreamVer }}" python-packages
+
+      - name: Building python package
+        run: |
+          python3 setup.py sdist --dist-dir /tmp/dist bdist_wheel --dist-dir /tmp/dist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: plenum-python
+          path: /tmp/dist
+          retention-days: 5
+
+
   publish_artifacts:
     name: Publish Artifacts
     runs-on: ubuntu-20.04
-    needs: [workflow-setup, build_release, build_3rd_party_dependencies]
+    needs: [workflow-setup, build_release, build_3rd_party_dependencies, build-python-packages]
     if: needs.workflow-setup.outputs.publish == 'true'
     env:
       GITHUB_REF: ${{ needs.workflow-setup.outputs.GITHUB_REF }}
@@ -440,3 +480,16 @@ jobs:
           sourceDirectory: /home/runner/tmp/third-party-dependencies
           distribution: ${{ needs.workflow-setup.outputs.distribution }}
           component: ${{ env.GITHUB_REF }}
+
+      - name: Download Python Packages from Pipeline Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: plenum-python
+          path: dist
+
+      - name: Publish Python Package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+

--- a/build-scripts/ubuntu-1604/build-indy-plenum.sh
+++ b/build-scripts/ubuntu-1604/build-indy-plenum.sh
@@ -14,7 +14,7 @@ cp -r ${INPUT_PATH}/. ${TMP_DIR}
 
 # prepare the sources
 cd ${TMP_DIR}/build-scripts/ubuntu-1604
-./prepare-package.sh ${TMP_DIR} ${VERSION}
+./prepare-package.sh ${TMP_DIR} plenum ${VERSION} debian-packages
 
 sed -i 's/{package_name}/'${PACKAGE_NAME}'/' "postinst"
 sed -i 's/{package_name}/'${PACKAGE_NAME}'/' "prerm"

--- a/build-scripts/ubuntu-1604/prepare-package.sh
+++ b/build-scripts/ubuntu-1604/prepare-package.sh
@@ -1,27 +1,43 @@
-#!/bin/bash -xe
+#!/bin/bash -ex
 
 if [ "$1" = "--help" ] ; then
-  echo "Usage: $0 <path-to-repo-folder> <release-version-dotted>"
+  echo "Usage: $0 <path-to-repo-folder> <main-module-name> <release-version-dotted> <distro-packages>"
+  echo "<distro-packages> - Set to 'debian-packages' when preparing deb packages, and 'python-packages' when preparing PyPi packages."
   exit 0
 fi
 
 repo="$1"
-version_dotted="$2"
+module_name="$2"
+version_dotted="$3"
+distro_packages="$4"
+
+BUMP_SH_SCRIPT="bump_version.sh"
+GENERATE_MANIFEST_SCRIPT="generate_manifest.sh"
 
 pushd $repo
 
 echo -e "\nSetting version to $version_dotted"
-bash -ex ./bump_version.sh $version_dotted
-cat plenum/__version__.json
+bash -ex $BUMP_SH_SCRIPT $version_dotted
+cat $module_name/__version__.json
 
 echo -e "\nGenerating manifest"
-bash -ex ./generate_manifest.sh
-cat plenum/__manifest__.json
+bash -ex $GENERATE_MANIFEST_SCRIPT
+cat $module_name/__manifest__.json
 
-echo -e "\nAdapt the dependencies for the Canonical archive"
-sed -i "s~ujson==1.33~ujson==1.33-1build1~" setup.py
-sed -i "s~prompt_toolkit==0.57~prompt_toolkit==0.57-1~" setup.py
-sed -i "s~msgpack-python==0.4.6~msgpack==0.4.6-1build1~" setup.py
+if [ "$distro_packages" = "debian-packages" ]; then
+  # Only used for the deb package builds, NOT for the PyPi package builds.
+  # Update the package names to match the versions that are pre-installed on the os.
+  echo -e "\nAdapt the dependencies for the Canonical archive"
+  sed -i "s~ujson==1.33~ujson==1.33-1build1~" setup.py
+  sed -i "s~prompt_toolkit==0.57~prompt_toolkit==0.57-1~" setup.py
+  sed -i "s~msgpack-python==0.4.6~msgpack==0.4.6-1build1~" setup.py
+elif [ "$distro_packages" = "python-packages" ]; then
+  echo -e "\nNo adaption of dependencies for python packages"
+else
+  echo -e "\nNo distribution specified. Please, specify distribution as 'debian-packages' or 'python-packages'."
+  exit 1
+fi
+
 popd
 
 echo -e "\nFinished preparing $repo for publishing\n"

--- a/build-scripts/ubuntu-2004/build-indy-plenum.sh
+++ b/build-scripts/ubuntu-2004/build-indy-plenum.sh
@@ -13,7 +13,7 @@ cp -r ${INPUT_PATH}/. ${TMP_DIR}
 
 # prepare the sources
 cd ${TMP_DIR}/build-scripts/ubuntu-2004
-./prepare-package.sh ${TMP_DIR} ${VERSION}
+./prepare-package.sh ${TMP_DIR} plenum ${VERSION} debian-packages
 
 sed -i 's/{package_name}/'${PACKAGE_NAME}'/' "postinst"
 sed -i 's/{package_name}/'${PACKAGE_NAME}'/' "prerm"

--- a/build-scripts/ubuntu-2004/prepare-package.sh
+++ b/build-scripts/ubuntu-2004/prepare-package.sh
@@ -1,27 +1,44 @@
-#!/bin/bash -xe
+#!/bin/bash -ex
 
 if [ "$1" = "--help" ] ; then
-  echo "Usage: $0 <path-to-repo-folder> <release-version-dotted>"
+  echo "Usage: $0 <path-to-repo-folder> <main-module-name> <release-version-dotted> <distro-packages>"
+  echo "<distro-packages> - Set to 'debian-packages' when preparing deb packages, and 'python-packages' when preparing PyPi packages."
   exit 0
 fi
 
 repo="$1"
-version_dotted="$2"
+module_name="$2"
+version_dotted="$3"
+distro_packages="$4"
+
+BUMP_SH_SCRIPT="bump_version.sh"
+GENERATE_MANIFEST_SCRIPT="generate_manifest.sh"
 
 pushd $repo
 
 echo -e "\nSetting version to $version_dotted"
-bash -ex ./bump_version.sh $version_dotted
-cat plenum/__version__.json
+bash -ex $BUMP_SH_SCRIPT $version_dotted
+cat $module_name/__version__.json
 
 echo -e "\nGenerating manifest"
-bash -ex ./generate_manifest.sh
-cat plenum/__manifest__.json
+bash -ex $GENERATE_MANIFEST_SCRIPT
+cat $module_name/__manifest__.json
 
-echo -e "\nAdapt the dependencies for the Canonical archive"
-# sed -i "s~ujson==1.35~ujson==1.35-4build1~" setup.py
-# sed -i "s~prompt_toolkit==2.0.10~prompt_toolkit==2.0.10-2~" setup.py
-# sed -i "s~msgpack-python==0.6.2~msgpack==0.4.6-1build1~" setup.py
+if [ "$distro_packages" = "debian-packages" ]; then
+  # Only used for the deb package builds, NOT for the PyPi package builds.
+  # Update the package names to match the versions that are pre-installed on the os.
+  echo -e "\nAdapt the dependencies for the Canonical archive"
+  #### ToDo adjust packages for the Cannonical archive for Ubuntu 20.04 (focal)
+  # sed -i "s~ujson==1.33~ujson==1.33-1build1~" setup.py
+  # sed -i "s~prompt_toolkit==0.57~prompt_toolkit==0.57-1~" setup.py
+  # sed -i "s~msgpack-python==0.4.6~msgpack==0.4.6-1build1~" setup.py
+elif [ "$distro_packages" = "python-packages" ]; then
+  echo -e "\nNo adaption of dependencies for python packages"
+else
+  echo -e "\nNo distribution specified. Please, specify distribution as 'debian-packages' or 'python-packages'."
+  exit 1
+fi
+
 popd
 
 echo -e "\nFinished preparing $repo for publishing\n"


### PR DESCRIPTION
This PR solves Issue #1555 and integrates the publishing of the Python package of Plenum to PyPI into the existing GHA workflow.

A successful run of the publishing to (Test)PyPI can be found [here](https://github.com/udosson/indy-plenum/actions/runs/1101535181).
The published Python package of Plenum can be found on Test-PyPI [indy-plenum 1.13.0.dev238](https://test.pypi.org/project/indy-plenum/1.13.0.dev238/)

Signed-off-by: udosson <r.klemens@yahoo.de>