### PR TITLE
Bug fix: Cache of 3rd party dependencies & uploading of existing packages to PyPI 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -472,7 +472,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/third-party-dependencies
-          key: third-party-dependencies-${{ hashFiles('./build-scripts/${{ env.UBUNTU_VERSION }}/build-3rd-parties.sh') }}
+          key: ${{ format('third-party-dependencies-{0}', hashFiles(format('./build-scripts/{0}/build-3rd-parties.sh', needs.workflow-setup.outputs.UBUNTU_VERSION ))) }}           
           
       - name: Publish 3rd Party Dependencies
         uses: ./.github/actions/publish-deb
@@ -492,4 +492,5 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+          skip_existing: true
 


### PR DESCRIPTION
This PR fixes two things:
- The cache key of the uploading of the 3rd party dependencies (deb) was different than the one from `build_3rd_party_dependencies` --> now the same
- When re-running all jobs of the pipeline and if the python packages have already been uploaded to PyPi in the previous one this caused an error --> now fixed by `skip existing`. (Solution was provided by @WadeBarnes)

Signed-off-by: udosson <r.klemens@yahoo.de>