### PR TITLE
fix uploading of deb files with the same name but different distribution

### DIFF
--- a/.github/actions/publish-deb/publishPackages
+++ b/.github/actions/publish-deb/publishPackages
@@ -26,7 +26,7 @@ for name in ${fileList}; do
   jfrog rt u \
     --deb ${distribution}/${component}/${architecture} \
     --spec ${uploadSpec}\
-    --spec-vars "SOURCE_DIR=${sourceDirectory};PACKAGE_NAME=${name};COMPONENT=${component};PACKAGE_STARTING_LETTER=${startingLetter};PACKAGE_SHORT_NAME=${shortName}" \
+    --spec-vars "SOURCE_DIR=${sourceDirectory};PACKAGE_NAME=${name};COMPONENT=${component};PACKAGE_STARTING_LETTER=${startingLetter};PACKAGE_SHORT_NAME=${shortName};DISTRIBUTION=${distribution}" \
     --detailed-summary
   echo "====================================================================================================================="
   echo

--- a/.github/actions/publish-deb/upload-spec.json
+++ b/.github/actions/publish-deb/upload-spec.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "pattern": "${SOURCE_DIR}/${PACKAGE_NAME}",
-      "target": "indy/pool/${COMPONENT}/${PACKAGE_STARTING_LETTER}/${PACKAGE_SHORT_NAME}/"
+      "target": "indy/pool/${DISTRIBUTION}/${COMPONENT}/${PACKAGE_STARTING_LETTER}/${PACKAGE_SHORT_NAME}/"
     }
   ]
 }


### PR DESCRIPTION
This small PR changes the structure of the artifacts uploaded to jfrog artifactory. This is because of conflicts that emerge when uploading deb files with the same name but different distributions.
The new structure will be as follows:
- `indy/pool/xenial/[dev, main, rc, stable]`
- `indy/pool/bionic/[dev, main, rc, stable]`
- `indy/pool/focal/[dev, main, rc, stable]`

Thanks to @WadeBarnes for the discussions we had about this.
The current error can be seen at https://github.com/hyperledger/indy-plenum/runs/3325278452?check_suite_focus=true `Publish 3rd Party Dependencies`.

>Note! A manual clean-up of the current artifacts stored in the jfrog artifactory is needed.

Signed-off-by: udosson <r.klemens@yahoo.de>