### PR TITLE
added label to pull correct lint image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -297,7 +297,7 @@ jobs:
     needs: [workflow-setup, lint-image]
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/${{ needs.workflow-setup.outputs.GITHUB_REPOSITORY_NAME }}/plenum-lint
+      image: ghcr.io/${{ needs.workflow-setup.outputs.GITHUB_REPOSITORY_NAME }}/plenum-lint:ubuntu-18-04
     steps:
       - name: Check out code
         uses: actions/checkout@v2


### PR DESCRIPTION
A small change that pins the `lint` docker image to the `ubuntu-18-04` label

Signed-off-by: udosson <r.klemens@yahoo.de>