### PR TITLE
Ubtuntu 20.04: fix uploading of deb files with the same name but different distribution

### DIFF
--- a/.github/actions/publish-deb/publishPackages
+++ b/.github/actions/publish-deb/publishPackages
@@ -26,7 +26,7 @@ for name in ${fileList}; do
   jfrog rt u \
     --deb ${distribution}/${component}/${architecture} \
     --spec ${uploadSpec}\
-    --spec-vars "SOURCE_DIR=${sourceDirectory};PACKAGE_NAME=${name};COMPONENT=${component};PACKAGE_STARTING_LETTER=${startingLetter};PACKAGE_SHORT_NAME=${shortName}" \
+    --spec-vars "SOURCE_DIR=${sourceDirectory};PACKAGE_NAME=${name};COMPONENT=${component};PACKAGE_STARTING_LETTER=${startingLetter};PACKAGE_SHORT_NAME=${shortName};DISTRIBUTION=${distribution}" \
     --detailed-summary
   echo "====================================================================================================================="
   echo

--- a/.github/actions/publish-deb/upload-spec.json
+++ b/.github/actions/publish-deb/upload-spec.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "pattern": "${SOURCE_DIR}/${PACKAGE_NAME}",
-      "target": "indy/pool/${COMPONENT}/${PACKAGE_STARTING_LETTER}/${PACKAGE_SHORT_NAME}/"
+      "target": "indy/pool/${DISTRIBUTION}/${COMPONENT}/${PACKAGE_STARTING_LETTER}/${PACKAGE_SHORT_NAME}/"
     }
   ]
 }


### PR DESCRIPTION
This PR cherry-picks the commit from #1563 and applies the same structure of uploading the debian packages to the `ubtuntu-20.04-upgrade` feature branch.

Signed-off-by: udosson <r.klemens@yahoo.de>