### PR TITLE
updated version of pygments because of security vulnerability

### DIFF
--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -257,7 +257,7 @@ options.setBuiltPkgs([
     'python3-setuptools': '38.5.2',
     'python3-dateutil': '2.6.1',
     'python3-semver': '2.7.9',
-    'python3-pygments': '2.2.0',
+    'python3-pygments': '2.7.4',
     'python3-psutil': '5.6.6',
     'python3-pyzmq': '18.1.0',
     'python3-intervaltree': '2.1.0',

--- a/build-scripts/ubuntu-1604/build-3rd-parties.sh
+++ b/build-scripts/ubuntu-1604/build-3rd-parties.sh
@@ -98,7 +98,7 @@ build_from_pypi sortedcontainers 1.5.7
 build_from_pypi setuptools 38.5.2
 build_from_pypi python-dateutil 2.6.1
 build_from_pypi semver 2.7.9
-build_from_pypi pygments 2.2.0
+build_from_pypi pygments 2.7.4
 build_from_pypi psutil 5.6.6
 build_from_pypi pyzmq 18.1.0 bundled
 build_from_pypi intervaltree 2.1.0

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
                         'jsonpickle==0.9.6',
                         'ujson==1.33',
                         'prompt_toolkit==0.57',
-                        'pygments==2.2.0',
+                        'pygments==2.7.4',
                         'rlp==0.5.1',
                         'sha3==0.2.1',
                         'leveldb',


### PR DESCRIPTION
This PR updates the version of  `pygments` to v.2.7.4 to fix the following CVEs (Issue #1540):
[CVE-2021-20270](https://github.com/advisories/GHSA-pq64-v7f5-gqh8)
[CVE-2021-27291](https://github.com/advisories/GHSA-pq64-v7f5-gqh8)



Signed-off-by: udosson <r.klemens@yahoo.de>