### PR TITLE
pinned dependencies because of missing support for python 3.5 and adjusted Jenkins CI

### DIFF
--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -65,7 +65,6 @@ def withTestEnv(body) {
 
         buildDocker("hyperledger/indy-plenum-ci", "ci/ubuntu.dockerfile ci").inside {
             echo 'Test: Install dependencies'
-            sh 'pip install pip==10.0.0'
             install()
             body.call('python')
         }

--- a/build-scripts/ubuntu-1604/Dockerfile
+++ b/build-scripts/ubuntu-1604/Dockerfile
@@ -28,8 +28,9 @@ RUN apt-get update -y && apt-get install -y \
 # issues with pip>=10:
 # https://github.com/pypa/pip/issues/5240
 # https://github.com/pypa/pip/issues/5221
-RUN python3 -m pip install -U pip setuptools \
-    && pip3 list
+RUN pip3 install -U \ 
+    pip \
+    'setuptools<=50.3.2' 
 
 # install fpm
 RUN gem install --no-ri --no-rdoc rake fpm

--- a/ci/code-validation.dockerfile
+++ b/ci/code-validation.dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update -y && apt-get install -y \
 	python-setuptools \
 	python3-nacl
 RUN pip3 install -U \
-	setuptools \
+	'setuptools<=50.3.2' \
 	pep8==1.7.1 \
 	pep8-naming==0.6.1 \
 	flake8==3.5.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(metadata['__file__'], 'r') as f:
     exec(f.read(), metadata)
 
 tests_require = ['attrs==19.1.0', 'pytest==3.3.1', 'pytest-xdist==1.22.1', 'pytest-forked==0.2',
-                 'python3-indy==1.15.0-dev-1625', 'pytest-asyncio==0.8.0']
+                 'python3-indy==1.16.0', 'pytest-asyncio==0.8.0']
 
 
 class PyZMQCommand(distutils.cmd.Command):
@@ -98,7 +98,7 @@ setup(
                         'jsonpickle==0.9.6',
                         'ujson==1.33',
                         'prompt_toolkit==0.57',
-                        'pygments==2.2.0',
+                        'pygments==2.7.4',
                         'rlp==0.5.1',
                         'sha3==0.2.1',
                         'leveldb',
@@ -108,7 +108,7 @@ setup(
                         'orderedset==2.0.3',
                         'sortedcontainers==1.5.7',
                         'psutil==5.6.6',
-                        'importlib_metadata>=2.0',
+                        'importlib-metadata==2.1.1',
                         'portalocker==0.5.7',
                         'libnacl==1.6.1',
                         'six==1.11.0',
@@ -118,7 +118,7 @@ setup(
                         'python-dateutil==2.6.1',
                         'pympler==0.8',
                         'packaging==19.0',
-                        'python-ursa==0.1.1',
+                        'python-ursa==0.1.1'
                       ],
 
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
Pinned the following PyPI packages to specific versions that are compatible with Python 3.5 and to fix CVEs.
- `setuptools<=50.3.2`
- `pygments==2.7.4` 
- `importlib_metadata==2.1.1`

Further, this PR fixed the issue of `python` executable related to the `virtualenv` of Jenkins CI.

Signed-off-by: udosson <r.klemens@yahoo.de>