### PR TITLE
added importlib-metadata as debian package

### DIFF
--- a/build-scripts/ubuntu-1604/README.md
+++ b/build-scripts/ubuntu-1604/README.md
@@ -24,7 +24,7 @@ Built packages are placed in a docker volume `indy-plenum-deb-u1604`.
 ### Build 3rd-party dependencies
 
 ```
-./build-3rd-parties-docker.sh <output-path: default='.'>
+./build-3rd-parties.sh <output-path: default='.'>
 ```
 
 Built packages are placed in the `output-path` folder.

--- a/build-scripts/ubuntu-1604/build-3rd-parties.sh
+++ b/build-scripts/ubuntu-1604/build-3rd-parties.sh
@@ -108,5 +108,6 @@ build_from_pypi python-rocksdb 0.6.9
 build_from_pypi pympler 0.8
 build_from_pypi packaging 19.0
 build_from_pypi python-ursa 0.1.1
+build_from_pypi importlib-metadata 2.1.1
 
 popd >/dev/null


### PR DESCRIPTION
Added missing 3rd party dependency `importlib-metadata` to the build process of the Debian packages.

Signed-off-by: udosson <r.klemens@yahoo.de>