### PR TITLE
updated version of setup-jfrog-cli to v2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -411,7 +411,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Setup JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v1
+        uses: jfrog/setup-jfrog-cli@v2
         env:
           JF_ARTIFACTORY_1: ${{ secrets.INDY_ARTIFACTORY_REPO_CONFIG }}
 


### PR DESCRIPTION
This PR updates the GitHub Action `setup-jfrog-cli` from `v1` to `v2`. The default version of the `jfrog-cli` changes from `v1.51.1` to `v2.3.0`.

Signed-off-by: udosson <r.klemens@yahoo.de>