### PR TITLE
added pygments, and zipp as 3rd party artifacts and updated version o…

### DIFF
--- a/build-scripts/ubuntu-1604/build-3rd-parties.sh
+++ b/build-scripts/ubuntu-1604/build-3rd-parties.sh
@@ -95,7 +95,7 @@ build_from_pypi libnacl 1.6.1
 build_from_pypi six 1.11.0
 build_from_pypi portalocker 0.5.7
 build_from_pypi sortedcontainers 1.5.7
-build_from_pypi setuptools 38.5.2
+build_from_pypi setuptools 50.3.2
 build_from_pypi python-dateutil 2.6.1
 build_from_pypi semver 2.7.9
 build_from_pypi pygments 2.2.0
@@ -109,5 +109,9 @@ build_from_pypi pympler 0.8
 build_from_pypi packaging 19.0
 build_from_pypi python-ursa 0.1.1
 build_from_pypi importlib-metadata 2.1.1
+# TODO: remove as install dependency because it is just needed for documentation
+build_from_pypi pygments 2.7.4
+# Is a dependency of importlib-metadata. In focal it is part of the Canonical archive
+build_from_pypi zipp 1.0.0
 
 popd >/dev/null


### PR DESCRIPTION
…f setuptools

This PR adds `pygments` and `zipp`  to the build-script of the 3rd party artifacts.
`Pygments` could probably removed in a future commit.
`zipp` is a dependency of `importlib-metadata`. In Ubuntu `focal`, `zipp` is of the Canonical archive (https://ubuntu.pkgs.org/20.04/ubuntu-main-amd64/python3-zipp_1.0.0-1_all.deb.html)

Also, this PR updates `setuptools` to the latest version with Python3.5 support

Signed-off-by: udosson <r.klemens@yahoo.de>