### PR TITLE
bump version of zipp to 1.2.0

### DIFF
--- a/build-scripts/ubuntu-1604/build-3rd-parties.sh
+++ b/build-scripts/ubuntu-1604/build-3rd-parties.sh
@@ -112,6 +112,6 @@ build_from_pypi importlib-metadata 2.1.1
 # TODO: remove as install dependency because it is just needed for documentation
 build_from_pypi pygments 2.7.4
 # Is a dependency of importlib-metadata. In focal it is part of the Canonical archive
-build_from_pypi zipp 1.0.0
+build_from_pypi zipp 1.2.0
 
 popd >/dev/null


### PR DESCRIPTION
Bump version of `zipp` from `1.0.0` to `1.2.0` because `zipp==1.0.0` depends on `more-itertools`. To reduce the number of dependencies this PR updates `zipp` to version `1.2.0` that doesn't depend on additional PyPI packages anymore.


Signed-off-by: udosson <r.klemens@yahoo.de>