### PR TITLE
updated version of setup-jfrog-cli to v2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -444,7 +444,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Setup JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v1
+        uses: jfrog/setup-jfrog-cli@v2
         env:
           JF_ARTIFACTORY_1: ${{ secrets.INDY_ARTIFACTORY_REPO_CONFIG }}
 


### PR DESCRIPTION
Cherry-picked commit https://github.com/hyperledger/indy-plenum/commit/765a499e5aa629261c89b6127f7e612f6dd130bf from master to upgrade version of `action/setup-jfrog-ci` to `v2`.

Signed-off-by: udosson <r.klemens@yahoo.de>