### PR TITLE
added versions of 3rd party packages to Debian artifacts

### DIFF
--- a/.github/workflows/build/Dockerfile.ubuntu-2004
+++ b/.github/workflows/build/Dockerfile.ubuntu-2004
@@ -10,7 +10,9 @@ RUN apt-get update -y && apt-get install -y \
     gnupg \
     apt-transport-https \
     ca-certificates \
-    apt-utils
+    apt-utils \
+    curl \
+    jq
 
 # ========================================================================================================
 # Update repository signing keys
@@ -65,8 +67,10 @@ RUN pip3 install -U \
     setuptools==50.3.2
 
 
-# install fpm
-RUN gem install --no-document rake fpm
+# install rake
+RUN gem install --no-document rake 
+## install fpm; needs to be pinned to 1.13.1 because some packages cannot be built with the newest release 1.14.0
+RUN gem install --no-document fpm -v 1.13.1
 
 RUN apt-get -y autoremove \
     && rm -rf /var/lib/apt/lists/*

--- a/build-scripts/ubuntu-2004/build-3rd-parties.sh
+++ b/build-scripts/ubuntu-2004/build-3rd-parties.sh
@@ -27,6 +27,10 @@ function build_from_pypi {
 
     if [ -z $2 ]; then
         PACKAGE_VERSION=""
+        # Get the most recent package version from PyPI to be included in the package name of the Debian artifact
+        curl -X GET "https://pypi.org/pypi/${PACKAGE_NAME}/json" > "${PACKAGE_NAME}.json"
+        PACKAGE_VERSION="==$(cat "${PACKAGE_NAME}.json" | jq --raw-output '.info.version')"
+        rm "${PACKAGE_NAME}.json"
     else
         PACKAGE_VERSION="==$2"
     fi
@@ -97,9 +101,9 @@ build_from_pypi pyzmq 18.1.0 bundled
 
 ##### install_requires
 build_from_pypi base58 
-build_from_pypi importlib_metadata
+build_from_pypi importlib-metadata 
 build_from_pypi ioflo 
-build_from_pypi jsonpickle 
+build_from_pypi jsonpickle
 build_from_pypi leveldb 
 build_from_pypi libnacl 1.6.1
 build_from_pypi msgpack-python
@@ -109,7 +113,7 @@ build_from_pypi portalocker
 build_from_pypi prompt-toolkit 3.0.18
 build_from_pypi psutil 
 build_from_pypi pympler 0.8
-build_from_pypi python-dateutil 
+build_from_pypi python-dateutil
 build_from_pypi python-rocksdb
 build_from_pypi python-ursa 0.1.1
 build_from_pypi rlp 0.6.0
@@ -118,5 +122,3 @@ build_from_pypi sha3
 build_from_pypi six 
 build_from_pypi sortedcontainers 1.5.7
 build_from_pypi ujson 1.33
-
-


### PR DESCRIPTION
This PR retrieves the most recent version of the third-party dependencies and includes the version number into the name of the artifacts published to Artifactory. This is needed because without it the artifacts get published with version `0.0.0` e.g.  `python3-importlib-metadata_0.0.0_amd64.deb` (https://hyperledger.jfrog.io/ui/native/indy/pool/focal/dev/i/importlib-metadata)

Signed-off-by: udosson <r.klemens@yahoo.de>