### PR TITLE
pinned version of importlib-metadata because of issue with fpm

### DIFF
--- a/build-scripts/ubuntu-2004/build-3rd-parties.sh
+++ b/build-scripts/ubuntu-2004/build-3rd-parties.sh
@@ -101,7 +101,9 @@ build_from_pypi pyzmq 18.1.0 bundled
 
 ##### install_requires
 build_from_pypi base58 
-build_from_pypi importlib-metadata 
+### Needs to be pinned to 3.10.1 because from v4.0.0 the package name ends in python3-importlib-metadata_0.0.0_amd64.deb
+### https://github.com/hyperledger/indy-plenum/runs/4166593170?check_suite_focus=true#step:5:5304
+build_from_pypi importlib-metadata 3.10.1
 build_from_pypi ioflo 
 build_from_pypi jsonpickle
 build_from_pypi leveldb 

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,8 @@ setup(
     install_requires=[
                         # 'base58==2.1.0',
                         'base58',
-                        'importlib_metadata>=2.0',
+                        # pinned because issue with fpm from v4.0.0
+                        'importlib_metadata==3.10.1',
                         # 'ioflo==2.0.2',
                         'ioflo',
                         # 'jsonpickle==2.0.0',


### PR DESCRIPTION
This PR pins the version of `importlib-metadata` to `v3.10.01`. From version `4.0.0`  on, the resulting package ends in `python3-importlib-metadata_0.0.0_amd64.deb`.

The issue can be seen at: https://github.com/hyperledger/indy-plenum/runs/4166593170?check_suite_focus=true#step:5:5304 

Signed-off-by: udosson <r.klemens@yahoo.de>