### PR TITLE
ReleaseWF and version bump

### DIFF
--- a/.github/actions/set-version/action.yaml
+++ b/.github/actions/set-version/action.yaml
@@ -44,8 +44,10 @@ runs:
 
         if [ ${{ inputs.isDev }} == "true" ] || [ ${{ inputs.isRC }} == "true" ]; then
           if [ ${{ inputs.isDev }} == "true" ]; then
+            pre="dev"
             rev=${{ github.run_number }}
           else
+            pre="rc"
             rev=${revision}
           fi
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,19 +1,8 @@
-name: Indy Plenum - Push and PR Workflow
+name: Indy Plenum - Release Workflow
 on:
-  push:
-    branches:
-      # - master
-      - ubuntu-20.04-upgrade
-    paths-ignore:
-      - 'plenum/__version_.json'
+  release:
+    types: [published]
 
-  pull_request:
-    branches:
-      # - master
-       - ubuntu-20.04-upgrade
-    paths-ignore:
-      - 'plenum/__version_.json'
-            
 jobs:
   workflow-setup:
     name: Initialize Workflow
@@ -44,27 +33,21 @@ jobs:
       - name: Set outputs
         id: cache
         run: |
-          # Set variables according to version of ubuntu
-          if [[ "${{github.base_ref}}" == "master" || "${{github.ref}}" == "refs/heads/master" ]]; then
-            echo "::set-output name=CACHE_KEY_BUILD::${{ hashFiles('.github/workflows/build/Dockerfile.ubuntu-1604') }}"
-            echo "::set-output name=UBUNTU_VERSION::ubuntu-1604"
-            echo "::set-output name=distribution::xenial"
-          fi
-          if [[ "${{github.base_ref}}" == "ubuntu-20.04-upgrade" || "${{github.ref}}" == "refs/heads/ubuntu-20.04-upgrade" ]]; then
-            echo "::set-output name=CACHE_KEY_BUILD::${{ hashFiles('.github/workflows/build/Dockerfile.ubuntu-2004') }}"
-            echo "::set-output name=UBUNTU_VERSION::ubuntu-2004"
-            echo "::set-output name=distribution::focal"
-          fi
+          
+          echo "::set-output name=CACHE_KEY_BUILD::${{ hashFiles('.github/workflows/build/Dockerfile.ubuntu-2004') }}"
+          echo "::set-output name=UBUNTU_VERSION::ubuntu-2004"
+          echo "::set-output name=distribution::focal"
+          
 
           if [[ "${{github.base_ref}}" == 'master' || "${{github.ref}}" == 'refs/heads/master' || "${{github.base_ref}}" == 'main' || "${{github.ref}}" == 'refs/heads/main' ]]; then
             echo "::set-output name=GITHUB_REF::main"
-          elif [[ "${{github.base_ref}}" == 'release*' || "${{github.ref}}" == 'refs/heads/release*' ]]; then
+          elif [[ ${{ github.event.release.prerelease }} == 'true' ]]; then
             echo "::set-output name=GITHUB_REF::rc"
-          elif [[ "${{github.base_ref}}" == 'stable' || "${{github.ref}}" == 'refs/heads/stable' ]]; then
+          elif [[ ${{ github.event.release.prerelease }} == 'false' ]]; then
             echo "::set-output name=GITHUB_REF::stable"
           else
             echo "::set-output name=GITHUB_REF::dev"
-          fi
+          fi         
 
       - name: Set build flags
         id: build-flags
@@ -82,12 +65,8 @@ jobs:
             echo "::set-output name=isRC::false"
           fi
 
-          # Ensure publishing is only performed when the build is executed from the main (hyperledger/indy-plenum) repository.
-          if [[ ${{github.event.repository.full_name}} == 'hyperledger/indy-plenum' && ${{github.event_name}} == 'push' && ( ${{steps.cache.outputs.GITHUB_REF}} == 'main' || ${{steps.cache.outputs.GITHUB_REF}} == 'rc' || ${{steps.cache.outputs.GITHUB_REF}} == 'stable' || ${{steps.cache.outputs.GITHUB_REF}} == 'dev' ) ]]; then
-            echo "::set-output name=publish::true"
-          else
-            echo "::set-output name=publish::false"
-          fi
+          echo "::set-output name=publish::true"
+
 
   lint:
     name: Lint
@@ -111,6 +90,7 @@ jobs:
       - name: Lint with flake8
         run: python3 -m flake8 .
 
+
   build-docker-image:
     name: Create Builder Image
     needs: [workflow-setup, lint]
@@ -120,10 +100,27 @@ jobs:
       GITHUB_REPOSITORY_NAME: ${{ needs.workflow-setup.outputs.GITHUB_REPOSITORY_NAME }}
       UBUNTU_VERSION: ${{ needs.workflow-setup.outputs.UBUNTU_VERSION }}
 
+  plenum_tests:
+    name: Test Plenum
+    needs: [workflow-setup, build-docker-image]
+    uses: ./.github/workflows/test.yaml
+    with:
+      GITHUB_REPOSITORY_NAME: ${{ needs.workflow-setup.outputs.GITHUB_REPOSITORY_NAME }}
+      UBUNTU_VERSION: ${{ needs.workflow-setup.outputs.UBUNTU_VERSION }}
+
+  build_packages:
+    name: Build Packages
+    needs: [workflow-setup, plenum_tests]
+    uses: ./.github/workflows/buildpackages.yaml
+    with:
+      GITHUB_REPOSITORY_NAME: ${{ needs.workflow-setup.outputs.GITHUB_REPOSITORY_NAME }}
+      UBUNTU_VERSION: ${{ needs.workflow-setup.outputs.UBUNTU_VERSION }}
+      isDev: ${{ needs.workflow-setup.outputs.isDev }}
+      isRC: ${{ needs.workflow-setup.outputs.isRC }}
+
   bump_version:
     name: Bump Version Number
     needs: [workflow-setup, build-docker-image]
-    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-20.04
     env:
       UBUNTU_VERSION: ${{ needs.workflow-setup.outputs.UBUNTU_VERSION }}
@@ -155,24 +152,6 @@ jobs:
           branch: update-version
           base: ubuntu-20.04-upgrade
 
-  plenum_tests:
-    name: Test Plenum
-    needs: [workflow-setup, lint, build-docker-image]
-    uses: ./.github/workflows/test.yaml
-    with:
-      GITHUB_REPOSITORY_NAME: ${{ needs.workflow-setup.outputs.GITHUB_REPOSITORY_NAME }}
-      UBUNTU_VERSION: ${{ needs.workflow-setup.outputs.UBUNTU_VERSION }}
-
-  build_packages:
-    name: Build Packages
-    needs: [workflow-setup, plenum_tests]
-    uses: ./.github/workflows/buildpackages.yaml
-    with:
-      GITHUB_REPOSITORY_NAME: ${{ needs.workflow-setup.outputs.GITHUB_REPOSITORY_NAME }}
-      UBUNTU_VERSION: ${{ needs.workflow-setup.outputs.UBUNTU_VERSION }}
-      isDev: ${{ needs.workflow-setup.outputs.isDev }}
-      isRC: ${{ needs.workflow-setup.outputs.isRC }}
-
   publish_artifacts:
     name: Publish Artifacts
     needs: [workflow-setup, build_packages]
@@ -183,5 +162,4 @@ jobs:
       UBUNTU_VERSION: ${{ needs.workflow-setup.outputs.UBUNTU_VERSION }}
       distribution: ${{ needs.workflow-setup.outputs.distribution }}
     secrets:
-      INDY_ARTIFACTORY_REPO_CONFIG: ${{ secrets.INDY_ARTIFACTORY_REPO_CONFIG }}
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Addition of the new release workflow, which will publish Github prereleases as prereleases to pypi and releases as releases.

The version bump is opening a PR with the changes done by the `buildscripts/ubuntu-2004/prepare-package.sh` script,
which is taking the version number from the `.github/actions/set-version/action.yaml`. 

To bump the version on normal pushes to the `ubuntu-20.04-upgrade` branch the `push_pr.yaml` has been changed that it will not trigger when the version bump PR (which is only changing the `'plenum/__version_.json'`)  is openend and merged.

Signed-off-by: pSchlarb <p.schlarb@esatus.com>