### PR TITLE
Upgrade zmq

### DIFF
--- a/.github/workflows/build/Dockerfile.ubuntu-2004
+++ b/.github/workflows/build/Dockerfile.ubuntu-2004
@@ -66,7 +66,6 @@ RUN pip3 install -U \
     # Required by setup.py
     setuptools==50.3.2
 
-
 # install rake
 RUN gem install --no-document rake 
 ## install fpm; needs to be pinned to 1.13.1 because some packages cannot be built with the newest release 1.14.0

--- a/build-scripts/ubuntu-1604/build-3rd-parties.sh
+++ b/build-scripts/ubuntu-1604/build-3rd-parties.sh
@@ -60,7 +60,7 @@ function build_from_pypi {
         fpm --input-type "python" \
             --output-type "deb" \
             --architecture "amd64" \
-            --python-setup-py-arguments "--zmq=bundled" \
+            --python-setup-py-arguments "${3}" \
             --verbose \
             --python-package-name-prefix "python3"\
             --python-bin "/usr/bin/python3" \
@@ -100,7 +100,7 @@ build_from_pypi python-dateutil 2.6.1
 build_from_pypi semver 2.7.9
 build_from_pypi pygments 2.2.0
 build_from_pypi psutil 5.6.6
-build_from_pypi pyzmq 18.1.0 bundled
+build_from_pypi pyzmq 22.3.0 --zmq=bundled
 build_from_pypi intervaltree 2.1.0
 build_from_pypi jsonpickle 0.9.6
 # TODO: add libsnappy dependency for python-rocksdb package

--- a/build-scripts/ubuntu-1604/build-indy-plenum.sh
+++ b/build-scripts/ubuntu-1604/build-indy-plenum.sh
@@ -22,7 +22,7 @@ sed -i 's/{package_name}/'${PACKAGE_NAME}'/' "prerm"
 fpm --input-type "python" \
     --output-type "deb" \
     --architecture "amd64" \
-    --depends "python3-pyzmq (= 18.1.0)" \
+    --depends "python3-pyzmq (= 22.3.0)" \
     --verbose \
     --python-package-name-prefix "python3"\
     --python-bin "/usr/bin/python3" \

--- a/build-scripts/ubuntu-2004/build-3rd-parties.sh
+++ b/build-scripts/ubuntu-2004/build-3rd-parties.sh
@@ -64,7 +64,7 @@ function build_from_pypi {
         fpm --input-type "python" \
             --output-type "deb" \
             --architecture "amd64" \
-            --python-setup-py-arguments "--zmq=bundled" \
+            --python-setup-py-arguments "${3}" \
             --verbose \
             --python-package-name-prefix "python3"\
             --python-bin "/usr/bin/python3" \
@@ -88,16 +88,16 @@ function build_from_pypi {
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 pushd `dirname ${SCRIPT_PATH}` >/dev/null
 
+# Install any python requirements needed for the builds.
+pip install -r requirements.txt
 
 # Build rocksdb at first
 ### Can be removed once the code has been updated to run with rocksdb v. 5.17
 ### Issue 1551: Update RocksDB; https://github.com/hyperledger/indy-plenum/issues/1551
 build_rocksdb_deb 5.8.8
 
-
 #### PyZMQCommand
-build_from_pypi pyzmq 18.1.0 bundled
-
+build_from_pypi pyzmq 22.3.0 --zmq=bundled
 
 ##### install_requires
 build_from_pypi base58 

--- a/build-scripts/ubuntu-2004/build-indy-plenum.sh
+++ b/build-scripts/ubuntu-2004/build-indy-plenum.sh
@@ -21,7 +21,7 @@ sed -i 's/{package_name}/'${PACKAGE_NAME}'/' "prerm"
 fpm --input-type "python" \
     --output-type "deb" \
     --architecture "amd64" \
-    --depends "python3-pyzmq (= 18.1.0)" \
+    --depends "python3-pyzmq (= 22.3.0)" \
     --verbose \
     --python-package-name-prefix "python3"\
     --python-bin "/usr/bin/python3" \

--- a/build-scripts/ubuntu-2004/requirements.txt
+++ b/build-scripts/ubuntu-2004/requirements.txt
@@ -1,0 +1,2 @@
+# Requirements for buuilding the python3-pyzmq_22.3.x_amd64.deb package.
+packaging

--- a/dev-setup/ubuntu/ubuntu-2004/SetupVMTest.txt
+++ b/dev-setup/ubuntu/ubuntu-2004/SetupVMTest.txt
@@ -73,7 +73,7 @@
             python-rocksdb==0.7.0 \
             python-ursa==0.1.1 \
             python3-indy==1.13.0 \
-            pyzmq==18.1.0 \
+            pyzmq==22.3.0 --install-option=--zmq=bundled \
             rlp==0.6.0 \
             semver==2.13.0 \
             setuptools==53.0.0 \

--- a/plenum/test/conftest.py
+++ b/plenum/test/conftest.py
@@ -127,10 +127,12 @@ def warnfilters():
             message='inspect\.getargspec\(\) is deprecated')
         warnings.filterwarnings(
             'ignore', category=ResourceWarning, message='unclosed event loop')
+        # These warnings occur when zmq sockets are still open when being garbage collected.
+        # The sockets are then automatically closed.
         warnings.filterwarnings(
             'ignore',
             category=ResourceWarning,
-            message='unclosed.*socket\.socket')
+            message='unclosed.*socket.*\<zmq\.Socket')
 
     return _
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ tests_require = ['attrs==20.3.0', 'pytest==6.2.2', 'pytest-xdist==2.2.1', 'pytes
 class PyZMQCommand(distutils.cmd.Command):
     description = 'pyzmq install target'
 
-    version = 'pyzmq==18.1.0'
+    version = 'pyzmq==22.3.0'
     options = '--install-option=--zmq=bundled'
 
     def initialize_options(self):

--- a/stp_zmq/remote.py
+++ b/stp_zmq/remote.py
@@ -74,17 +74,16 @@ class Remote:
 
     def connect(self, context, localPubKey, localSecKey, typ=None):
         typ = typ or zmq.DEALER
-        sock = context.socket(typ)
-        sock.curve_publickey = localPubKey
-        sock.curve_secretkey = localSecKey
-        sock.curve_serverkey = self.publicKey
-        sock.identity = localPubKey
-        set_keepalive(sock, self.config)
-        set_zmq_internal_queue_size(sock, self.queue_size)
+        self.socket = context.socket(typ)
+        self.socket.curve_publickey = localPubKey
+        self.socket.curve_secretkey = localSecKey
+        self.socket.curve_serverkey = self.publicKey
+        self.socket.identity = localPubKey
+        set_keepalive(self.socket, self.config)
+        set_zmq_internal_queue_size(self.socket, self.queue_size)
         addr = '{protocol}://{bind_ip}:0;{}:{}'.format(*self.ha, bind_ip=self.bind_ip, protocol=ZMQ_NETWORK_PROTOCOL)
-        logger.trace('connecting socket {} to remote {}, addr: {}'.format(sock.FD, self, addr))
-        sock.connect(addr)
-        self.socket = sock
+        logger.trace('connecting socket {} to remote {}, addr: {}'.format(self.socket.FD, self, addr))
+        self.socket.connect(addr)
 
     def close_monitor_socket(self):
         if self.socket._monitor_socket:

--- a/stp_zmq/zstack.py
+++ b/stp_zmq/zstack.py
@@ -419,6 +419,7 @@ class ZStack(NetworkInterface):
             self._conns = set()
         else:
             if self.listener_monitor is not None:
+                self.listener_monitor.linger = 0
                 self.listener.disable_monitor()
                 self.listener_monitor = None
             self.listener.unbind(self.listener.LAST_ENDPOINT)


### PR DESCRIPTION
- Upgrade to the latest version of `pyzmq`, and update warning filters to ignore the new format of the unclosed socket messages.
- Clean up PAIR sockets as best as possible.
- Fix issue with building the deb for `pyzmq`.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>