### PR TITLE
Upgrade to SovrinHelpers v2.2.4

### DIFF
--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library('SovrinHelpers@v2.2.3') _
+@Library('SovrinHelpers@v2.2.4') _
 
 
 String name = 'indy-plenum'


### PR DESCRIPTION
- SovrinHelpers v2.2.4 includes an update to fix dependency issues in `pypi-publish.dockerfile` and `pr-automerge.dockerfile` affecting the CD pipeline.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>