### PR TITLE
Upgrade pipeline to follow SovrinHelpers v2.2

### DIFF
--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library('SovrinHelpers@v2.2.4') _
+@Library('SovrinHelpers@v2.2') _
 
 
 String name = 'indy-plenum'


### PR DESCRIPTION
- SovrinHelpers v2.2.5 includes an update to fix dependency issues in `pypi-publish.dockerfile` affecting the CD pipeline.
- A v2.2 tag was added to the jenkins-shared repo so additional issues can be fix and the tag moved to the latest version.  This will help eliminate having to follow the specific version and update the indy-plenum pipelines each time.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>