### PR TITLE
correctly pass ledger_id to the timestamp state storage

### DIFF
--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -1756,7 +1756,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
                         (ledger_id == DOMAIN_LEDGER_ID or ledger_id == CONFIG_LEDGER_ID):
                     timestamp = get_txn_time(txn)
                     if timestamp is not None:
-                        self.stateTsDbStorage.set(timestamp, state.headHash)
+                        self.stateTsDbStorage.set(timestamp, state.headHash, ledger_id=ledger_id)
                 logger.trace("{} added transaction with seqNo {} to ledger {} during catchup, state root {}"
                              .format(self, get_seq_no(txn), ledger_id,
                                      state_roots_serializer.serialize(bytes(state.committedHeadHash))))

--- a/plenum/test/node_catchup/test_ts_store_after_catchup.py
+++ b/plenum/test/node_catchup/test_ts_store_after_catchup.py
@@ -1,5 +1,5 @@
 from common.serializers.serialization import domain_state_serializer, config_state_serializer
-from plenum.common.constants import DOMAIN_LEDGER_ID, GET_TXN_AUTHOR_AGREEMENT
+from plenum.common.constants import CONFIG_LEDGER_ID, GET_TXN_AUTHOR_AGREEMENT
 from plenum.common.txn_util import get_req_id, get_from, get_txn_time, get_payload_data
 from plenum.common.util import get_utc_epoch
 from plenum.server.request_handlers.static_taa_helper import StaticTAAHelper
@@ -86,7 +86,7 @@ def test_fill_ts_store_for_config_after_catchup(txnPoolNodeSet,
     req_handler = node_to_disconnect.read_manager.request_handlers[GET_TXN_AUTHOR_AGREEMENT]
     last_digest = StaticTAAHelper.get_taa_digest(req_handler.state)
     key = StaticTAAHelper.state_path_taa_digest(last_digest)
-    root_hash = req_handler.database_manager.ts_store.get_equal_or_prev(get_txn_time(sdk_reply[1]['result']))
+    root_hash = req_handler.database_manager.ts_store.get_equal_or_prev(get_txn_time(sdk_reply[1]['result']), ledger_id=CONFIG_LEDGER_ID)
     assert root_hash
     from_state = req_handler.state.get_for_root_hash(root_hash=root_hash,
                                                      key=key)


### PR DESCRIPTION
Fixes an issue during catch-up that caused all timestamps to get written into the domain_ledger ts storage, ignoring the config_ledger.

Signed-off-by: Christian Bormann <ChristianCarl.Bormann@de.bosch.com>