### PR TITLE
Trigger Node Update

### DIFF
--- a/.github/workflows/publishRelease.yaml
+++ b/.github/workflows/publishRelease.yaml
@@ -126,20 +126,14 @@ jobs:
     needs: [release-infos, publish_artifacts]
     steps:
       - name: Convert to python version flavour
+        uses: hyperledger/indy-shared-gha/.github/workflows/pyVersionConversion.yaml@v1
+        with:
+          VERSIONTAG: ${{ needs.release-infos.outputs.VERSIONTAG }}
         id: conversion
-        run: |
-          pyVersion=$(echo ${{ needs.release-infos.outputs.VERSIONTAG }} | sed 's~v~~g')
-          if [[ ${{ needs.release-infos.outputs.VERSIONTAG }} == *"-"* ]]; then
-            pyVersion=$(echo $pyVersion | sed 's~-~.~g')
-            echo "pyVersion=$pyVersion">> $GITHUB_OUTPUT
-          else
-            echo "pyVersion=$pyVersion" >> $GITHUB_OUTPUT
-          fi
-          echo "debVersion=$(echo $pyVersion | sed -E 's/^([^\.]*\.[^\.]*\.[^\.]*)\.(.*)$/\1~\2/')" >> $GITHUB_OUTPUT
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.BOT_PR_PAT_NODE }}
-          repository: pschlarb/indy-node
+          token: ${{ secrets.BOT_PR_PAT }}
+          repository: hyperledger/indy-node
           event-type: update-node
           client-payload: '{"pyVersion": "${{ steps.conversion.outputs.pyVersion }}", "debVersion": "${{ steps.conversion.outputs.debVersion }}", "email":"${{ github.event.pusher.email }}"}'

--- a/.github/workflows/publishRelease.yaml
+++ b/.github/workflows/publishRelease.yaml
@@ -121,15 +121,25 @@ jobs:
       INDY_ARTIFACTORY_REPO_CONFIG: ${{ secrets.INDY_ARTIFACTORY_REPO_CONFIG }}
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
   
-  # WIP: Triggering a node Upgrade after Plenum has been updated
-  # triggerNodeUpdate:
-  #   runs-on: ubuntu-latest
-  #   needs: [release-infos, publish_artifacts]
-  #   steps:
-  #     - name: Repository Dispatch
-  #       uses: peter-evans/repository-dispatch@v2
-  #       with:
-  #         token: ${{ secrets.NEOBOT }}
-  #         repository: wadebarnes/workflow-trigger-test
-  #         event-type: plenum-updated
-  #         client-payload: '{"version": "${{ needs.release_infos.outputs.version }}"}'
+  triggerNodeUpdate:
+    runs-on: ubuntu-latest
+    needs: [release-infos, publish_artifacts]
+    steps:
+      - name: Convert to python version flavour
+        id: conversion
+        run: |
+          pyVersion=$(echo ${{ needs.release-infos.outputs.VERSIONTAG }} | sed 's~v~~g')
+          if [[ ${{ needs.release-infos.outputs.VERSIONTAG }} == *"-"* ]]; then
+            pyVersion=$(echo $pyVersion | sed 's~-~.~g')
+            echo "pyVersion=$pyVersion">> $GITHUB_OUTPUT
+          else
+            echo "pyVersion=$pyVersion" >> $GITHUB_OUTPUT
+          fi
+          echo "debVersion=$(echo $pyVersion | sed -E 's/^([^\.]*\.[^\.]*\.[^\.]*)\.(.*)$/\1~\2/')" >> $GITHUB_OUTPUT
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.BOT_PR_PAT_NODE }}
+          repository: pschlarb/indy-node
+          event-type: update-node
+          client-payload: '{"pyVersion": "${{ steps.conversion.outputs.pyVersion }}", "debVersion": "${{ steps.conversion.outputs.debVersion }}", "email":"${{ github.event.pusher.email }}"}'


### PR DESCRIPTION
The BOT_PR_PAT_NODE Secrets needs to be set with a fine grained access token for node so that it can trigger the workflow there. 

Needs https://github.com/hyperledger/indy-node/pull/1812 to be merged first or the trigger won't work.