### PR TITLE
Pin jsonpickle to 3.0.3

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -47,7 +47,7 @@ jobs:
                       packaging \
                       python-dateutil \
                       msgpack-python \
-                      jsonpickle
+                      jsonpickle=3.0.3
       - name: Prepare package and set version
         run: |
           ./bump_version.sh ${{ needs.taginfos.outputs.VERSION }}

--- a/build-scripts/ubuntu-2004/build-3rd-parties.sh
+++ b/build-scripts/ubuntu-2004/build-3rd-parties.sh
@@ -108,7 +108,7 @@ build_from_pypi base58
 ### https://github.com/hyperledger/indy-plenum/runs/4166593170?check_suite_focus=true#step:5:5304
 build_from_pypi importlib-metadata 3.10.1
 build_from_pypi ioflo
-build_from_pypi jsonpickle
+build_from_pypi jsonpickle 3.0.3
 build_from_pypi leveldb
 build_from_pypi libnacl 1.6.1
 build_from_pypi msgpack-python

--- a/dev-setup/ubuntu/ubuntu-2004/SetupVMTest.txt
+++ b/dev-setup/ubuntu/ubuntu-2004/SetupVMTest.txt
@@ -48,7 +48,7 @@
             iniconfig==1.1.1 \
             intervaltree==2.1.0 \
             ioflo==2.0.2 \
-            jsonpickle==2.0.0 \
+            jsonpickle==3.0.3 \
             leveldb==0.201 \
             libnacl==1.7.2 \
             mccabe==0.6.1 \

--- a/setup.py
+++ b/setup.py
@@ -101,8 +101,7 @@ setup(
                         'importlib_metadata==3.10.1',
                         # 'ioflo==2.0.2',
                         'ioflo',
-                        # 'jsonpickle==2.0.0',
-                        'jsonpickle',
+                        'jsonpickle==3.0.3',
                         # 'leveldb==0.201',
                         'leveldb',
                         # Pinned because of changing size of `crypto_sign_SECRETKEYBYTES` from 32 to 64


### PR DESCRIPTION
- v3.0.3 is the last version of jsonpickle that contains the setup.py file required by fpm to build the third party package.
- This is intended as an interim fix for the main branch to allow the workflows to complete.
- Work on the `ubuntu-22.04` branch uses `wheel2deb` to build `deb` packages for the newer python modules.