### PR TITLE
Update action-download-artifact actions

### DIFF
--- a/.github/workflows/publishRelease.yaml
+++ b/.github/workflows/publishRelease.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download Plenum deb Artifacts from Github Action Artifacts
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: releasepr.yaml
@@ -59,7 +59,7 @@ jobs:
           name: plenum-deb
           path: artifacts/plenum-deb
       - name: Download Plenum python Artifacts from Github Action Artifacts
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: releasepr.yaml
@@ -67,7 +67,7 @@ jobs:
           name: plenum-python
           path: artifacts/plenum-python
       - name: Download Plenum third party dependency Artifacts from Github Action Artifacts
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: releasepr.yaml


### PR DESCRIPTION
- Update to the latest version of action-download-artifact.
- Do not update the indy-shared-gha actions to v2 on the 20.04 branch. v2 is for the 22.04 branch.