### PR TITLE
[Security] Remove sha3 (CVE-2022-37454)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,8 +127,6 @@ setup(
                         ### Tests fail without version pin (GHA run: https://github.com/udosson/indy-plenum/actions/runs/1078745445)
                         'rlp==0.6.0',
                         'semver==2.13.0',
-                        # 'sha3==0.2.1',
-                        'sha3',
                         # 'six==1.15.0',
                         'six',
                         ### Tests fail without version pin (GHA run: https://github.com/udosson/indy-plenum/actions/runs/1078741118)

--- a/state/util/utils.py
+++ b/state/util/utils.py
@@ -3,14 +3,9 @@ import string
 
 
 import hashlib
-if hasattr(hashlib, 'sha3_256'):
-    def sha3_256(x):
-        return hashlib.sha3_256(x).digest()
-else:
-    import sha3 as _sha3
-    def sha3_256(x):
-        return _sha3.sha3_256(x).digest()
 
+def sha3_256(x):
+    return hashlib.sha3_256(x).digest()
 
 import rlp
 from rlp.sedes import big_endian_int, BigEndianInt, Binary


### PR DESCRIPTION
This package was not critical and features are implemented within hashlib, as pointed out by the package maintainers:
https://github.com/tiran/pysha3

Package is archived.