### PR TITLE
test: Add workflow permissions for test report publishing

### DIFF
--- a/.github/workflows/reuseable_test.yaml
+++ b/.github/workflows/reuseable_test.yaml
@@ -10,6 +10,10 @@ on:
         required: true
         type: string
 
+permissions:
+  checks: write
+  contents: read
+
 jobs:
   indy_plenum_tests:
     name: Sliced Module Tests

--- a/runner.py
+++ b/runner.py
@@ -1,3 +1,4 @@
+# Test workflow permissions fix - Adding comment to verify test report publishing
 import os
 import re
 import sys


### PR DESCRIPTION
# Fix Test Report Publishing

## Problem
GitHub Actions workflow failing to publish test reports due to missing permissions ("Resource not accessible by integration" error).

## Solution
Added required workflow permissions:
- `checks: write` for test reports
- `contents: read` for code access

Fixes #1710